### PR TITLE
feat(#25): Global OSC transport (TotalMix FX 2.1)

### DIFF
--- a/bridge.py
+++ b/bridge.py
@@ -404,13 +404,11 @@ class TotalMixOSCBridge:
                     snap_num = (snap_val.get("index") or snap_key)                         if isinstance(snap_val, dict) else snap_key
                     break
             if snap_num is not None:
+                # recall stays classic under every transport (#25 TASK 11:
+                # Global snapshot feedback unreliable; classic confirm isn't)
                 osc_addr = f"/3/snapshots/{snapshot_num_to_osc_index(snap_num)}/1"
                 with self._device_lock:
-                    if self._global_active():
-                        # #25: 1-based Global recall, feedback-confirmed
-                        self.global_transport.load_snapshot(int(snap_num))
-                    else:
-                        self.osc_client.send_message(osc_addr, 1.0)
+                    self.osc_client.send_message(osc_addr, 1.0)
                 self._outputs_cache = None
                 self._inputs_cache = None
                 self._layout_epoch = time.time()
@@ -585,22 +583,15 @@ class TotalMixOSCBridge:
                     if self.state_confirmed:
                         self._layout_epoch = time.time()
 
-                if snap_name and snap_num is not None and self._global_active():
-                    # #25: Global snapshot recall — 1-BASED address, no 9-N
-                    # button inversion, confirmed by feedback value 2.0
-                    ok = self.global_transport.load_snapshot(int(snap_num))
-                    self._outputs_cache = None
-                    self._inputs_cache = None
-                    self._layout_epoch = time.time()
-                    self.current_snapshot = snap_name
-                    self.state_confirmed = bool(ok)
-                    logger.info(f"   → Switched snapshot to '{snap_name}' via "
-                                f"Global OSC (/snapshot/load/{int(snap_num)}) "
-                                f"confirmed={ok}")
-                    if self.mqtt_client:
-                        self.mqtt_client.publish("totalmix/snapshot", str(snap_num), retain=True)
-                        logger.info(f"   → Published to HA → totalmix/snapshot = {snap_num}")
-                elif snap_name and snap_num is not None:
+                # #25 NOTE: snapshot recall deliberately stays CLASSIC even
+                # under the global transport. TASK 11 (2026-08-21) measured
+                # Global /snapshot/load feedback as unreliable — load/4
+                # never confirmed (2s penalty each) and the snapshots dict
+                # went stale vs reality — while classic button-echo confirm
+                # is 0.02–0.08s and consistent. The classic remote stays
+                # configured regardless (workspace switching has no Global
+                # equivalent), so this costs nothing.
+                if snap_name and snap_num is not None:
                     osc_addr = f"/3/snapshots/{snapshot_num_to_osc_index(snap_num)}/1"
                     t0 = time.time()
                     self.osc_client.send_message(osc_addr, 1.0)

--- a/bridge.py
+++ b/bridge.py
@@ -143,6 +143,8 @@ class TotalMixOSCBridge:
         self._macro_lock = threading.Lock() # guards the three structures above (web + MQTT + queued threads)
         self.mqtt_connected = False         # set True/False by mqtt_handler callbacks
         self.osc_listener = None            # OSCListener — set by start_osc_listener()
+        self.global_listener = None         # GlobalOSCListener (#25) — start_global_osc()
+        self.global_transport = None        # GlobalTransport (#25) — active or shadow
         self.state_confirmed = None         # last commanded switch confirmed by device feedback?
         self.last_probe = None              # result of the last device liveness probe
         self.sweep_state = {"status": "idle"}      # physical-table sweep job state (#24)
@@ -404,7 +406,11 @@ class TotalMixOSCBridge:
             if snap_num is not None:
                 osc_addr = f"/3/snapshots/{snapshot_num_to_osc_index(snap_num)}/1"
                 with self._device_lock:
-                    self.osc_client.send_message(osc_addr, 1.0)
+                    if self._global_active():
+                        # #25: 1-based Global recall, feedback-confirmed
+                        self.global_transport.load_snapshot(int(snap_num))
+                    else:
+                        self.osc_client.send_message(osc_addr, 1.0)
                 self._outputs_cache = None
                 self._inputs_cache = None
                 self._layout_epoch = time.time()
@@ -579,7 +585,22 @@ class TotalMixOSCBridge:
                     if self.state_confirmed:
                         self._layout_epoch = time.time()
 
-                if snap_name and snap_num is not None:
+                if snap_name and snap_num is not None and self._global_active():
+                    # #25: Global snapshot recall — 1-BASED address, no 9-N
+                    # button inversion, confirmed by feedback value 2.0
+                    ok = self.global_transport.load_snapshot(int(snap_num))
+                    self._outputs_cache = None
+                    self._inputs_cache = None
+                    self._layout_epoch = time.time()
+                    self.current_snapshot = snap_name
+                    self.state_confirmed = bool(ok)
+                    logger.info(f"   → Switched snapshot to '{snap_name}' via "
+                                f"Global OSC (/snapshot/load/{int(snap_num)}) "
+                                f"confirmed={ok}")
+                    if self.mqtt_client:
+                        self.mqtt_client.publish("totalmix/snapshot", str(snap_num), retain=True)
+                        logger.info(f"   → Published to HA → totalmix/snapshot = {snap_num}")
+                elif snap_name and snap_num is not None:
                     osc_addr = f"/3/snapshots/{snapshot_num_to_osc_index(snap_num)}/1"
                     t0 = time.time()
                     self.osc_client.send_message(osc_addr, 1.0)
@@ -622,11 +643,23 @@ class TotalMixOSCBridge:
             # input row selected — both persist on the device and silently
             # mis-target every later macro (review finding).
             _bank_dirty = False
-            _row_dirty = any(str(s.get("target", {}).get("row", 1)) in ("2", "3")
-                             for s in macro.get("steps", []) if "target" in s)
+            # target steps never touch classic row state under the global
+            # transport, so they cannot dirty it
+            _row_dirty = (not self._global_active() and
+                          any(str(s.get("target", {}).get("row", 1)) in ("2", "3")
+                              for s in macro.get("steps", []) if "target" in s))
             try:
              for step in macro.get("steps", []):
                 osc_addr = step.get("osc")
+
+                # #25: name-targeted steps route through the Global
+                # transport when selected — absolute addressing, no aiming,
+                # no bank/row state to dirty or restore. Raw-OSC steps
+                # (classic namespace) fall through to the classic path.
+                if "target" in step and self._global_active():
+                    self._run_step_global(step, macro_name, value,
+                                          cancel_event, clock_bpm)
+                    continue
 
                 # CRASH GUARD for RAW steps: /setSubmix past the last real
                 # output crashes TotalMix (hardware root cause). A raw index
@@ -797,7 +830,7 @@ class TotalMixOSCBridge:
                 "progress": 100,
                 "lfo_active": False,
                 "last_trigger": time.time(),
-                "osc_preview": f"{macro_data.get('steps', [{}])[0].get('osc', '')} = {value:.3f}",
+                "osc_preview": f"{(macro_data.get('steps') or [{}])[0].get('osc', '')} = {value:.3f}",
                 "routing_label": self.get_routing_label(macro_name),
                 "midi_trigger": macro_data.get("midi_triggers", [{}])[0] if macro_data.get("midi_triggers") else None,
             }
@@ -1641,6 +1674,87 @@ class TotalMixOSCBridge:
                     logger.debug(f"startup summary failed: {e}")
             threading.Thread(target=_startup_summary, daemon=True).start()
 
+    # ─────────────────────────────────────────────────────────────
+    # GLOBAL OSC (#25): second remote, absolute addressing
+    # ─────────────────────────────────────────────────────────────
+    def _global_active(self):
+        """True when macro writes route through the Global transport.
+        Workspace switching stays classic regardless (no Global equivalent)."""
+        return OSC_TRANSPORT == "global" and self.global_transport is not None
+
+    def start_global_osc(self):
+        """Start the Global OSC listener (+ transport). In shadow mode
+        (ENABLE_GLOBAL_OSC_LISTENER=true, OSC_TRANSPORT=classic) the
+        listener observes and learns names while classic keeps writing."""
+        if not ENABLE_GLOBAL_OSC_LISTENER:
+            return
+        from global_listener import GlobalOSCListener
+        from global_transport import GlobalTransport
+        listener = GlobalOSCListener(GLOBAL_OSC_LISTEN_PORT)
+        if not listener.start():
+            logger.error("Global OSC listener failed to start — "
+                         "global transport unavailable")
+            return
+        self.global_listener = listener
+        client = get_client(GLOBAL_OSC_IP, GLOBAL_OSC_PORT)
+        self.global_transport = GlobalTransport(
+            client, listener, self._physical_table,
+            persist_cb=self._persist_after_global_names,
+            heartbeat_timeout_s=GLOBAL_HEARTBEAT_TIMEOUT_S)
+        self.global_transport.start()
+        mode = ("TRANSPORT ACTIVE" if OSC_TRANSPORT == "global"
+                else "shadow mode (observing only)")
+        logger.info(f"Global OSC {mode} → {GLOBAL_OSC_IP}:{GLOBAL_OSC_PORT} "
+                    f"(listening on {listener.port})")
+
+    def stop_global_osc(self):
+        if self.global_transport:
+            self.global_transport.stop()
+            self.global_transport = None
+        if self.global_listener:
+            self.global_listener.stop()
+            self.global_listener = None
+
+    def _persist_after_global_names(self):
+        if self.channel_map and not self.channel_map_is_example:
+            self._persist_channel_map_file(self.channel_map)
+
+    def _run_step_global(self, step, macro_name, value, cancel_event,
+                         clock_bpm):
+        """One name-targeted step over the Global transport. Handles its
+        own refusal events; raw-OSC steps never reach here (they stay on
+        the classic client — their addresses are classic-namespace)."""
+        writer, label, status = self.global_transport.resolve_step(
+            step["target"])
+        if status != "resolved":
+            logger.error(f"   → step skipped (global): {label!r} "
+                         f"unresolved ({status})")
+            self.broadcast_state(macro_event={
+                "type": "macro_skipped",
+                "name": macro_name,
+                "reason": f"target_{status}",
+            })
+            return
+        if "operation" in step and step.get("value") == "{{param}}":
+            op_config = step["operation"]
+            if op_config.get("bpm") == "clock":
+                resolved_bpm = clock_bpm if clock_bpm else 140
+                op_config = {**op_config, "bpm": resolved_bpm}
+                logger.info(f"   → BPM clock sync: using {resolved_bpm} BPM")
+            # Global switches are absolute sets (no edge-toggle shim
+            # needed): the writer's to_wire threshold turns the 0..1
+            # stream into clean 0/1 writes.
+            OperationRegistry.execute(
+                op_config["type"], writer, writer.address, value,
+                op_config, cancel_event=cancel_event)
+        else:
+            step_val = value if step.get("value") == "{{param}}" else step.get("value")
+            try:
+                writer.send_message(writer.address, float(step_val))
+                logger.info(f"   → {writer.address} = {step_val} (global)")
+            except Exception as e:
+                logger.error(f"Global OSC send failed: {e}")
+
     def start_mqtt(self):
         """Connect MQTT and start the client loop (web and standalone modes)."""
         logger.info("=== TOTALMIX OSC BRIDGE STARTING MQTT (web or standalone mode) ===")
@@ -1667,6 +1781,7 @@ logger.info("State-aware workspace/snapshot switching (NO force) + OperationRegi
 if __name__ == "__main__":
     bridge.start_mqtt()   # re-uses the same function
     bridge.start_osc_listener()
+    bridge.start_global_osc()   # #25: no-op unless enabled via env
 
     try:
         while True:

--- a/config.py
+++ b/config.py
@@ -26,6 +26,23 @@ OSC_MONITOR_PORT = int(os.getenv('OSC_MONITOR_PORT', '9001'))
 # the monitor and the listener cannot share the port simultaneously.
 ENABLE_OSC_LISTENER = os.getenv('ENABLE_OSC_LISTENER', 'True').lower() == 'true'
 OSC_LISTEN_PORT = int(os.getenv('OSC_LISTEN_PORT', os.getenv('OSC_MONITOR_PORT', '9001')))
+# === GLOBAL OSC TRANSPORT (#25 — TotalMix FX 2.1+ 'Global OSC' remote) ===
+# OSC_TRANSPORT selects the macro write path: 'classic' (default, the
+# proven aim-and-write path) or 'global' (absolute addressing, no aiming).
+# The Global remote is a SECOND remote in TotalMix (Remote 2) with its own
+# port pair — classic stays configured either way (workspace switching has
+# no Global equivalent).
+OSC_TRANSPORT = os.getenv('OSC_TRANSPORT', 'classic').strip().lower()
+GLOBAL_OSC_IP = os.getenv('GLOBAL_OSC_IP', os.getenv('OSC_IP') or '127.0.0.1')
+GLOBAL_OSC_PORT = int(os.getenv('GLOBAL_OSC_PORT', '7002'))
+GLOBAL_OSC_LISTEN_PORT = int(os.getenv('GLOBAL_OSC_LISTEN_PORT', '9002'))
+# Shadow mode: run the Global listener for observation/name-learning even
+# while the classic transport still does the writing.
+ENABLE_GLOBAL_OSC_LISTENER = (
+    os.getenv('ENABLE_GLOBAL_OSC_LISTENER', 'False').lower() == 'true'
+    or OSC_TRANSPORT == 'global')
+GLOBAL_HEARTBEAT_TIMEOUT_S = float(os.getenv('GLOBAL_HEARTBEAT_TIMEOUT_S', '5'))
+
 # === LOGGING SETTINGS (100 KB limit per file) ===
 BRIDGE_LOG_FILE = os.getenv('BRIDGE_LOG_FILE', 'bridge.log')
 OSC_MONITOR_LOG_FILE = os.getenv('OSC_MONITOR_LOG_FILE', 'osc_monitor.log')

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -186,19 +186,43 @@ Hardware-in-the-loop scripts (real MQTT broker, real UFX II) live in `tests/manu
 
 ---
 
-## Device capture (channel-map discovery)
+## TotalMix OSC configuration (the canonical client setup)
 
-The bridge listens for TotalMix's OSC feedback and can build `ufx2_channel_map.json` by interrogating the device — no more clicking through submixes with the log monitor.
+The bridge uses up to TWO OSC remotes in TotalMix, configured in
+**Options → Mixer Settings (F3) → OSC tab** (TotalMix FX 2.1; older
+versions call it Settings). Each remote is selected with the
+"Remote Controller Select" radio buttons.
 
-**One-time TotalMix configuration** (Options → Settings → OSC):
+**Remote 1 — classic protocol (required; drives macros today):**
 
 | Setting | Value |
 |---|---|
-| In Use | checked (Remote Controller Select 1) |
+| In Use | checked |
 | Port incoming | `7001` (must match `OSC_PORT`) |
 | Port outgoing | `9001` (must match `OSC_LISTEN_PORT`) |
 | IP or Host Name | IP of the machine running the bridge |
-| Number of Faders per Bank | **high enough to cover every channel** (e.g. 32) |
+| Number of Faders per Bank | **high enough to cover every channel** (e.g. 48) |
+| Compatibility (Mode) | `TotalMix 1.96` (the classic/default mode) |
+
+**Remote 2 — Global OSC (TotalMix FX 2.1+; the next-generation transport,
+issue #25):**
+
+| Setting | Value |
+|---|---|
+| In Use | checked |
+| Port incoming | `7002` (`GLOBAL_OSC_PORT`) |
+| Port outgoing | `9002` (`GLOBAL_OSC_LISTEN_PORT`) |
+| IP or Host Name | IP of the machine running the bridge |
+| Compatibility (Mode) | `Global OSC` |
+| Details… → Send changes | checked |
+| Details… → Send status cyclic | **checked** (the ~1/sec heartbeat the bridge uses for liveness) |
+| Details… → Receive on hidden channels | **checked** (hidden channels are otherwise silently dropped) |
+| Details… → Re-send options | **unchecked** (RME warns of ping-pong loops) |
+| Details… → Bandwidth Limitation | `500kByte/s` (default) |
+
+Also in the **Options menu**: "Enable OSC Control" checked; "Submix linked
+to OSC Controller 1" as required by the classic protocol; do NOT enable
+submix-linking for the Global remote.
 
 The fader-bank size matters: TotalMix only reports the strips inside the
 current bank over OSC. At the default of 8, discovery and live resolution can
@@ -207,19 +231,27 @@ appear. Raise it, then re-run discovery. (The bridge sends `/setBankStart 0`
 before every capture/resolution so a scrolled bank cannot shift indices —
 the address is 0-based.)
 
-**Several OSC settings are workspace-scoped and will NOT survive a workspace
-load unless you re-save the workspace after changing them.** Confirmed the
-hard way, twice:
+**CRITICAL: every OSC remote setting above is WORKSPACE-scoped and will NOT
+survive a workspace load unless you re-save the workspace.** Confirmed the
+hard way, three times now:
 
 | Setting | Observed behavior |
 |---|---|
 | Number of Faders per Bank | reverted 48 → 8 on workspace load |
-| Remote Controller Address | set, then gone after a TotalMix restart |
+| Remote Controller Address | wiped on workspace load (kills feedback = macros stop) |
+| Remote 2 "In Use" + mode | wiped on workspace load (kills Global OSC entirely) |
 
-The non-obvious required step: change the setting **while the workspace you
-perform in is loaded**, then **re-save that workspace** (and every other
-workspace you switch to — each carries its own copy). Loading any workspace
-— including by a macro — restores that workspace's stored values.
+The required procedure, **once per quick-workspace slot you ever load**
+(including by macros):
+
+1. Load the workspace (File → Workspace Quick Select, or fire a macro).
+2. Configure both remotes as above (the load just reverted them).
+3. **File → Workspace Quick Select → "Save current workspace as…"** — the
+   dialog prefills the current slot number and name; click Save.
+
+After that, loads of that workspace carry the settings and nothing breaks.
+A workspace you never load can keep stale settings harmlessly — but the
+moment something loads it, both remotes revert until it too is re-saved.
 
 Separately, stereo-link state and channel names change per **snapshot** —
 the bridge handles that at fire time by resolving channel names against live
@@ -233,20 +265,28 @@ states, not two: **48 = good, 8 = the workspace's bank setting was lost,
 0/null = nothing received yet** (not a narrow bank — run the connection
 check from the gear menu, or fire any macro, to prime it).
 
-**Run a discovery walk:**
+**First run — measure the device (one time per physical interface):**
+
+Click **"Measure channels"** on the setup banner in the web UI, or:
 
 ```bash
-# Start the walk (~16s with defaults: 16 submixes x 1s settle)
-curl -X POST http://YOUR-SERVER:8088/api/device/discover \
-  -H 'Content-Type: application/json' -d '{"submix_count": 16, "settle_s": 1.0}'
+# ~35s, read-only: reads each hardware channel's name at every fixed
+# position, both rows. Never switches submixes or writes parameters.
+curl -X POST http://YOUR-SERVER:8088/api/device/sweep \
+  -H 'Content-Type: application/json' -d '{}'
 
-# Poll for the result
-curl http://YOUR-SERVER:8088/api/device/discovery
-
-# Happy with it? Promote it to the live channel map (auto-backup first)
-curl -X POST http://YOUR-SERVER:8088/api/device/discovery/apply
+# Poll status / inspect the measured table
+curl http://YOUR-SERVER:8088/api/device/sweep
+curl http://YOUR-SERVER:8088/api/device/physical_table
 ```
 
-The walk selects each output submix in TotalMix (you will see the mixer switch submixes — do it while not performing), records the channel names and addresses the device reports, and writes a draft to `discovered_channel_map.json`.
+The sweep builds the *physical table* — hardware channel → observed names —
+which is the only stored mapping the bridge needs. It never goes stale:
+hardware positions are fixed; snapshots only rename/pair strips, and the
+bridge learns those aliases automatically as it runs. Re-run the sweep only
+if you replace the interface or want to reset accumulated aliases
+(`{"reset": true}`).
 
-`GET /api/device/state` shows everything the listener has captured, including a raw dump of every OSC address TotalMix has sent — useful for finding addresses for new mapping types.
+`GET /api/device/state` shows everything the classic listener has captured;
+`GET /api/device/picker` shows the live channel inventory the macro editor
+uses.

--- a/global_listener.py
+++ b/global_listener.py
@@ -1,0 +1,202 @@
+"""Global OSC feedback listener (#25).
+
+Deliberately a SEPARATE implementation from osc_listener.py: DeviceState is
+bank/strip/submix-scoped with burst heuristics that are meaningless under
+absolute addressing. The proven scaffolding PATTERNS are mirrored —
+blocking single-threaded server (ordering), event-driven wait_for waiters,
+per-message exception containment, stop() that closes the socket — but the
+state model is (row, hw_channel, param) with REAL units and timestamps.
+
+Wire facts baked in (verified 2026-08-20/21): feedback arrives as OSC
+bundles (python-osc unframes them before dispatch — verified live, HW-1);
+cyclic status heartbeat ~1/s on /status/device|connection|dsp; channel
+numbers are 0-based hardware-mono — identical to physical_table keys;
+names arrive at the LEFT member only (unlike page-2 sweeps).
+"""
+import logging
+import threading
+import time
+
+from pythonosc.dispatcher import Dispatcher
+from pythonosc.osc_server import BlockingOSCUDPServer
+
+logger = logging.getLogger(__name__)
+
+ROW_KEYS = {"input": "inputs", "playback": "playbacks", "output": "outputs"}
+
+
+class GlobalDeviceState:
+    """Thread-safe store of everything Global OSC has told us."""
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self.params = {}      # (row_key, hw, param_path) -> {"value", "ts"}
+        self.names = {}       # row_key -> {hw: {"name", "ts"}}
+        self.stereo = {}      # row_key -> {hw: bool}
+        self.mix = {}         # (src 'in'|'pb', in_hw, out_hw, param) -> {"value","ts"}
+        self.status = {}      # status name -> value
+        self.snapshots = {}   # snap_num -> feedback value (0 off / 2 active / 3 changed)
+        self.last_heartbeat = 0.0
+        self.message_count = 0
+        self.pending_name_changes = set()   # (row_key, hw) — drained by the sync
+
+    def heartbeat_age(self):
+        with self._lock:
+            if not self.last_heartbeat:
+                return None
+            return time.time() - self.last_heartbeat
+
+    def get_param(self, row_key, hw, param_path):
+        with self._lock:
+            e = self.params.get((row_key, int(hw), param_path))
+            return (e["value"], e["ts"]) if e else None
+
+    def get_mix(self, src, in_hw, out_hw, param):
+        with self._lock:
+            e = self.mix.get((src, int(in_hw), int(out_hw), param))
+            return (e["value"], e["ts"]) if e else None
+
+    def channel_names(self, row_key):
+        with self._lock:
+            return {hw: e["name"] for hw, e in self.names.get(row_key, {}).items()}
+
+    def ingest(self, address, args):
+        now = time.time()
+        arg0 = args[0] if args else None
+        parts = address.strip("/").split("/")
+        if not parts:
+            return
+        head = parts[0]
+        with self._lock:
+            self.message_count += 1
+            if head == "status":
+                if len(parts) >= 2:
+                    self.status[parts[1]] = arg0
+                self.last_heartbeat = now
+                return
+            if head == "level":
+                return  # high-rate meters — deliberately not stored
+            if head in ("in", "input", "playback", "output") and head in ROW_KEYS:
+                if len(parts) < 3:
+                    return
+                row_key = ROW_KEYS[head]
+                try:
+                    hw = int(parts[1])
+                except ValueError:
+                    return
+                path = "/".join(parts[2:])
+                if path == "name":
+                    name = str(arg0).strip() if arg0 is not None else ""
+                    prev = self.names.setdefault(row_key, {}).get(hw, {}).get("name")
+                    self.names[row_key][hw] = {"name": name, "ts": now}
+                    if name and name != prev:
+                        self.pending_name_changes.add((row_key, hw))
+                    return
+                if path == "stereo":
+                    self.stereo.setdefault(row_key, {})[hw] = bool(
+                        arg0 is not None and float(arg0) >= 0.5)
+                    # a link change re-scopes the pair's alias merge
+                    self.pending_name_changes.add((row_key, hw))
+                    return
+                self.params[(row_key, hw, path)] = {"value": arg0, "ts": now}
+                return
+            if head == "mix" and len(parts) >= 5:
+                src = parts[1]              # 'in' | 'pb'
+                try:
+                    in_hw, out_hw = int(parts[2]), int(parts[3])
+                except ValueError:
+                    return
+                param = "/".join(parts[4:])
+                self.mix[(src, in_hw, out_hw, param)] = {"value": arg0, "ts": now}
+                return
+            if head == "snapshot" and len(parts) >= 3 and parts[1] == "load":
+                try:
+                    self.snapshots[int(parts[2])] = float(arg0 or 0)
+                except (ValueError, TypeError):
+                    pass
+                return
+            # everything else (reverb/echo/controlroom/...) → flat store
+            self.params[("fx", 0, address.strip("/"))] = {"value": arg0, "ts": now}
+
+    def drain_name_changes(self):
+        with self._lock:
+            changed = list(self.pending_name_changes)
+            self.pending_name_changes.clear()
+            return changed
+
+
+class GlobalOSCListener:
+    """UDP server feeding GlobalDeviceState. Same waiter/containment
+    patterns as the classic OSCListener."""
+
+    def __init__(self, port):
+        self.port = port
+        self.state = GlobalDeviceState()
+        self._server = None
+        self._thread = None
+        self._waiters = []
+        self._waiters_lock = threading.Lock()
+
+    def wait_for(self, predicate, timeout):
+        if predicate(self.state):
+            return True
+        ev = threading.Event()
+        entry = (predicate, ev)
+        with self._waiters_lock:
+            self._waiters.append(entry)
+        try:
+            if predicate(self.state):
+                return True
+            return ev.wait(timeout)
+        finally:
+            with self._waiters_lock:
+                if entry in self._waiters:
+                    self._waiters.remove(entry)
+
+    def start(self):
+        dispatcher = Dispatcher()
+        dispatcher.set_default_handler(self._handle, needs_reply_address=False)
+        try:
+            # Blocking single-threaded: ordering within a bundle burst is
+            # preserved; handlers are microseconds of dict work
+            self._server = BlockingOSCUDPServer(("0.0.0.0", self.port), dispatcher)
+        except OSError as e:
+            logger.error(f"Global OSC listener could not bind UDP {self.port}: {e}")
+            self._server = None
+            return False
+        self.port = self._server.server_address[1]
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+        logger.info(f"Global OSC listener started → UDP {self.port}")
+        return True
+
+    def stop(self):
+        if self._server:
+            self._server.shutdown()
+            self._server.server_close()   # else EADDRINUSE on restart
+            self._server = None
+            if self._thread:
+                self._thread.join(timeout=2.0)
+            logger.info("Global OSC listener stopped")
+
+    @property
+    def running(self):
+        return self._server is not None
+
+    def _handle(self, address, *args):
+        try:
+            self.state.ingest(address, args)
+        except Exception as e:
+            # one malformed element must never drop the rest of the packet
+            logger.warning(f"Global OSC ingest error on {address} {args!r}: {e}")
+            return
+        if self._waiters:
+            with self._waiters_lock:
+                waiters = list(self._waiters)
+            for predicate, ev in waiters:
+                if not ev.is_set():
+                    try:
+                        if predicate(self.state):
+                            ev.set()
+                    except Exception:
+                        ev.set()

--- a/global_transport.py
+++ b/global_transport.py
@@ -1,0 +1,247 @@
+"""Global OSC transport (#25) — absolute-addressed writes, no aiming.
+
+The write path in full: a macro step's name-based target resolves to a
+fixed hardware channel (live name cache first, physical-table aliases as
+fallback), the param maps to its Global address + unit transform
+(global_units.GLOBAL_PARAM_MAP), and the writer sends one absolutely-
+addressed message. No /setSubmix, no /setBankStart, no bank/row state, no
+restores, no settle windows — the concepts do not exist in this namespace.
+
+Writers satisfy the OperationRegistry client duck-type (send_message(label,
+normalized_value)) so ramps/LFOs work unchanged: operations.py keeps
+emitting the classic 0..1 domain and the writer converts per message.
+
+Liveness = the cyclic status heartbeat (~1/s when 'Send status cyclic' is
+enabled on the remote). Uncalibrated unit transforms REFUSE — units are
+never guessed.
+"""
+import logging
+import threading
+import time
+
+import global_units as gu
+import physical_table as pt
+
+logger = logging.getLogger(__name__)
+
+ROW_WORDS = {"1": "input", "2": "playback", "3": "output"}
+ROW_KEYS = {"1": "inputs", "2": "playbacks", "3": "outputs"}
+
+
+class MixSendWriter:
+    """A submix send: /mix/in|pb/{in_hw}/{out_hw}/<path>."""
+
+    def __init__(self, client, src, in_hw, out_hw, gp):
+        self._client = client
+        self.address = f"/mix/{src}/{in_hw}/{out_hw}/{gp.path}"
+        self._gp = gp
+
+    def send_message(self, _label, value):
+        self._client.send_message(self.address, float(self._gp.to_wire(value)))
+
+
+class ChannelParamWriter:
+    """A channel-scoped param: /input|playback|output/{hw}/<path>.
+    L/R params (gp.lr) address the pair's RIGHT member at hw+1."""
+
+    def __init__(self, client, row_word, hw, gp, path=None):
+        self._client = client
+        n = hw + 1 if gp.lr else hw
+        self.address = f"/{row_word}/{n}/{path or gp.path}"
+        self._gp = gp
+
+    def send_message(self, _label, value):
+        self._client.send_message(self.address, float(self._gp.to_wire(value)))
+
+
+class FxWriter:
+    """Global FX: fixed absolute address (/reverb/..., /echo/...)."""
+
+    def __init__(self, client, gp):
+        self._client = client
+        self.address = gp.path
+        self._gp = gp
+
+    def send_message(self, _label, value):
+        self._client.send_message(self.address, float(self._gp.to_wire(value)))
+
+
+class GlobalTransport:
+    name = "global"
+    NAME_SYNC_INTERVAL_S = 2.0
+
+    def __init__(self, client, listener, table_provider, persist_cb=None,
+                 heartbeat_timeout_s=5.0):
+        """client: OSC sender aimed at TotalMix's Global remote port.
+        listener: GlobalOSCListener (caller starts/stops it).
+        table_provider: () -> physical_table dict (bridge._physical_table).
+        persist_cb: () -> None, debounced persist after alias merges."""
+        self._client = client
+        self.listener = listener
+        self._table = table_provider
+        self._persist_cb = persist_cb
+        self.heartbeat_timeout_s = heartbeat_timeout_s
+        self._sync_thread = None
+        self._sync_stop = threading.Event()
+
+    # ── lifecycle ───────────────────────────────────────────────────
+    def start(self):
+        # bootstrap: one full dump fills names/params/mix caches (the
+        # remote's bandwidth limiter absorbs the burst)
+        self._client.send_message("/sendall", 1.0)
+        self._sync_stop.clear()
+        self._sync_thread = threading.Thread(target=self._name_sync_loop,
+                                             daemon=True)
+        self._sync_thread.start()
+        logger.info("Global transport started (bootstrap /sendall sent)")
+
+    def stop(self):
+        self._sync_stop.set()
+        if self._sync_thread:
+            self._sync_thread.join(timeout=3.0)
+            self._sync_thread = None
+
+    # ── resolution ──────────────────────────────────────────────────
+    def _hw_for_name(self, row_key, name):
+        """Live name cache first (freshest truth), physical-table aliases
+        second. Names live at the LEFT pair member under Global."""
+        wanted = str(name).strip().lower()
+        live = self.listener.state.channel_names(row_key)
+        for hw, live_name in live.items():
+            if live_name.strip().lower() == wanted:
+                return hw
+        table = self._table()
+        hw = pt.resolve_start(table, row_key, name) if table is not None else None
+        if hw is None:
+            return None
+        # The mono-name-while-linked default: a name like "AN 2" lives at
+        # the right member's offset. If the pair is CURRENTLY linked (live
+        # stereo flag at the even-aligned left member), the right member is
+        # not an addressable strip — default to the pair. When mono, the
+        # offset is the channel itself and stands.
+        if hw % 2 == 1 and self.listener.state.stereo.get(row_key, {}).get(hw - 1):
+            return hw - 1
+        return hw
+
+    def resolve_step(self, target):
+        """target: mappings-format dict {channel, submix?, row?, param?}.
+        -> (writer|None, human_label, status)."""
+        param = str(target.get("param", "volume")).strip().lower()
+        row = str(target.get("row", 1))
+        channel = str(target.get("channel", "")).strip()
+        submix = str(target.get("submix", "")).strip()
+
+        gp = gu.GLOBAL_PARAM_MAP.get(param)
+        if gp is None:
+            return None, param, "unsupported_param"
+        if not gp.calibrated:
+            # unit transform not wire-measured yet — never guess units
+            return None, param, "uncalibrated_param"
+
+        if gp.scope == "fx":
+            return FxWriter(self._client, gp), f"FX {param}", "resolved"
+
+        row_word, row_key = ROW_WORDS.get(row), ROW_KEYS.get(row)
+        if row_word is None:
+            return None, param, "unsupported_param"
+
+        # channel-detail params do not exist on the software playback row
+        # (hardware-verified in the classic era; the namespace mirrors it)
+        detail = gp.scope == "channel" and param not in ("mute",)
+        if detail and row == "2" and param != "volume":
+            return None, param, "playback_no_detail"
+
+        hw = self._hw_for_name(row_key, channel)
+        if hw is None:
+            return None, channel, "not_in_table"
+
+        if gp.scope == "channel":
+            return (ChannelParamWriter(self._client, row_word, hw, gp),
+                    f"{channel} {param}", "resolved")
+
+        # mix scope: volume/pan. Row-3 targets are the output's own fader.
+        if row == "3":
+            return (ChannelParamWriter(self._client, "output", hw, gp,
+                                       path=gp.path),
+                    f"{channel} {param} (output)", "resolved")
+        if not submix:
+            return None, channel, "not_in_table"
+        out_hw = self._hw_for_name("outputs", submix)
+        if out_hw is None:
+            return None, submix, "not_in_table"
+        src = "pb" if row == "2" else "in"
+        return (MixSendWriter(self._client, src, hw, out_hw, gp),
+                f"{channel} → {submix} {param}", "resolved")
+
+    # ── queries ─────────────────────────────────────────────────────
+    def channel_names(self, row_key):
+        return self.listener.state.channel_names(row_key)
+
+    def read_param(self, row_key, hw, param_path):
+        return self.listener.state.get_param(row_key, hw, param_path)
+
+    # ── liveness ────────────────────────────────────────────────────
+    def alive(self):
+        age = self.listener.state.heartbeat_age()
+        if age is not None and age < self.heartbeat_timeout_s:
+            return {"alive": True, "method": "heartbeat",
+                    "age_s": round(age, 3), "at": time.time()}
+        # one refresh attempt before the verdict
+        before = self.listener.state.message_count
+        self._client.send_message("/sendstate", 1.0)
+        got = self.listener.wait_for(
+            lambda s: s.message_count > before, 2.0)
+        age = self.listener.state.heartbeat_age()
+        return {"alive": bool(got), "method": "heartbeat+sendstate",
+                "age_s": round(age, 3) if age is not None else None,
+                "at": time.time()}
+
+    # ── switching ───────────────────────────────────────────────────
+    def load_snapshot(self, snap_num, timeout=2.0):
+        """Global OSC snapshot recall: 1-BASED, no 9-N button inversion.
+        Confirmed by feedback /snapshot/load/{n} == 2.0 ('active')."""
+        n = int(snap_num)
+        self._client.send_message(f"/snapshot/load/{n}", 1.0)
+        return self.listener.wait_for(
+            lambda s: s.snapshots.get(n) == 2.0, timeout)
+
+    # ── feedback -> physical table alias sync ──────────────────────
+    def _name_sync_loop(self):
+        while not self._sync_stop.wait(self.NAME_SYNC_INTERVAL_S):
+            try:
+                self.sync_names_once()
+            except Exception as e:
+                logger.warning(f"global name sync error: {e}")
+
+    def sync_names_once(self):
+        changed = self.listener.state.drain_name_changes()
+        if not changed:
+            return 0
+        table = self._table()
+        if table is None:
+            return 0
+        merged = 0
+        st = self.listener.state
+        for row_key, hw in changed:
+            entry = st.names.get(row_key, {}).get(hw)
+            if not entry or not entry.get("name"):
+                continue
+            name = entry["name"]
+            if pt.merge_observation(table, row_key, hw, name):
+                merged += 1
+            # a pair's alias list lives at BOTH member offsets — the
+            # classic invariant resolve_start()/covers() depend on. Global
+            # names arrive at the LEFT member only, so mirror to hw+1 when
+            # the stereo flag says linked.
+            if st.stereo.get(row_key, {}).get(hw):
+                if pt.merge_observation(table, row_key, hw + 1, name):
+                    merged += 1
+        if merged and self._persist_cb:
+            try:
+                self._persist_cb()
+            except Exception as e:
+                logger.warning(f"table persist after name sync failed: {e}")
+        if merged:
+            logger.info(f"physical table learned {merged} alias(es) from "
+                        f"Global OSC feedback")
+        return merged

--- a/global_transport.py
+++ b/global_transport.py
@@ -199,7 +199,13 @@ class GlobalTransport:
     # ── switching ───────────────────────────────────────────────────
     def load_snapshot(self, snap_num, timeout=2.0):
         """Global OSC snapshot recall: 1-BASED, no 9-N button inversion.
-        Confirmed by feedback /snapshot/load/{n} == 2.0 ('active')."""
+        Confirmed by feedback /snapshot/load/{n} == 2.0 ('active').
+
+        NOT wired into the bridge (TASK 11, 2026-08-21): the load itself
+        works every time, but the confirmation feedback is unreliable in
+        2.1 b5 (load/4 never confirmed; snapshots dict went stale vs
+        reality). Bridge snapshot recall stays on the classic button-echo
+        path until RME's feedback firms up — then this is ready."""
         n = int(snap_num)
         self._client.send_message(f"/snapshot/load/{n}", 1.0)
         return self.listener.wait_for(

--- a/global_units.py
+++ b/global_units.py
@@ -1,0 +1,188 @@
+"""Global OSC unit conversions + the declarative param map (#25).
+
+Macros and the UI operate in the classic 0..1 normalized domain per param
+(PARAM_DEFS). Global OSC speaks REAL units (dB, Hz, ms, Q) on most
+addresses, plus `faderlin` — a 0..1 fader position whose dB curve RME
+publishes in the protocol spec (Fader curve sheet, ported verbatim below).
+
+Every transform is declarative in GLOBAL_PARAM_MAP so protocol drift during
+the 2.1 beta stays localized here. Params whose real-unit ranges have NOT
+been wire-calibrated yet carry to_wire=None — the transport REFUSES them
+rather than guessing (the width-assumption lesson, generalized to units).
+Spec version pinned: globalosc_protocol_b2.zip, table dated 21.07.26.
+"""
+
+# Wire value observed for -infinity dB (e.g. fxsend of an off send)
+GAIN_SUBMIX_OFF = -300.0
+
+_FADER_BREAK = 649.0
+_FADER_SLOPE = 0.0320855615
+_FADER_OFFSET = -26.8235294118
+
+
+def fader_db(faderlin: float) -> float:
+    """RME CalcFaderDB: faderlin position 0..1 -> dB (verbatim port)."""
+    pos = max(0.0, min(1.0, float(faderlin))) * 1023.0
+    if pos >= _FADER_BREAK:
+        db = pos * _FADER_SLOPE + _FADER_OFFSET
+    else:
+        db = (pos * pos) * (-1.0 / 11033.0) + pos * 0.1497326203 - 65.0
+    if db < -64.9:
+        return GAIN_SUBMIX_OFF
+    return db
+
+
+def fader_lin(db: float) -> float:
+    """RME CalcFaderLin: dB -> faderlin position 0..1 (verbatim port)."""
+    db = float(db)
+    if db <= -64.9:
+        return 0.0
+    if db >= -6.0:
+        pos = (db - _FADER_OFFSET) * (1.0 / _FADER_SLOPE)
+    else:
+        pos = 826.0 - ((-34869.0 - 11033.0 * db) ** 0.5)
+    return max(0.0, min(1.0, pos * (1.0 / 1023.0)))
+
+
+def _clamp01(v):
+    return max(0.0, min(1.0, float(v)))
+
+
+def _identity(v):
+    return _clamp01(v)
+
+
+def _to_balpan(v):
+    """classic pan 0..1 (L..R) -> balpan -1..+1"""
+    return _clamp01(v) * 2.0 - 1.0
+
+
+def _from_balpan(w):
+    return _clamp01((float(w) + 1.0) / 2.0)
+
+
+def _to_switch(v):
+    """threshold at 0.5 -> absolute 0|1 (Global enables are absolute sets,
+    unlike classic's momentary buttons — gate HW-3)"""
+    return 1.0 if float(v) >= 0.5 else 0.0
+
+
+def _from_switch(w):
+    return 1.0 if float(w) >= 0.5 else 0.0
+
+
+def _linear(lo, hi):
+    span = hi - lo
+
+    def to_wire(v):
+        return lo + _clamp01(v) * span
+
+    def from_wire(w):
+        return _clamp01((float(w) - lo) / span)
+
+    return to_wire, from_wire
+
+
+def _enum4(v):
+    """classic eq-type enum {0.0, 0.3333, 0.6667, 1.0} -> index 0..3"""
+    return float(round(_clamp01(v) * 3.0))
+
+
+def _from_enum4(w):
+    return max(0.0, min(3.0, float(w))) / 3.0
+
+
+class GlobalParam:
+    """One classic param's Global OSC binding.
+
+    scope: 'mix'     — /mix/in|pb/{in}/{out}/<path> (submix sends)
+           'channel' — /input|playback|output/{n}/<path>
+           'fx'      — fixed tree (/reverb/..., /echo/...)
+    path:  address tail
+    lr:    True when the RIGHT half of a pair is addressed at n+1
+    to_wire/from_wire: normalized<->real transforms; to_wire=None means
+           UNCALIBRATED — the transport must refuse (never guess units).
+    """
+
+    def __init__(self, scope, path, to_wire, from_wire, lr=False):
+        self.scope = scope
+        self.path = path
+        self.to_wire = to_wire
+        self.from_wire = from_wire
+        self.lr = lr
+
+    @property
+    def calibrated(self):
+        return self.to_wire is not None
+
+
+_dyn_gain = _linear(-30.0, 30.0)
+_comp_thresh = _linear(-60.0, 0.0)
+_ratio = _linear(1.0, 10.0)
+_exp_thresh = _linear(-99.0, -20.0)
+_attack = _linear(0.0, 200.0)
+_release = _linear(100.0, 999.0)
+_alev_maxgain = _linear(0.0, 18.0)
+_alev_headroom = _linear(3.0, 12.0)
+_alev_risetime = _linear(0.1, 9.9)
+
+GLOBAL_PARAM_MAP = {
+    # ── page-1 domain ───────────────────────────────────────────────
+    # volume rides faderlin: same 0..1 domain as classic (identity gated
+    # by HW-2; fall back to fader_lin(classic->dB) if the curve differs)
+    "volume": GlobalParam("mix", "faderlin", _identity, _identity),
+    "pan":    GlobalParam("mix", "balpan", _to_balpan, _from_balpan),
+    "mute":   GlobalParam("channel", "mute", _to_switch, _from_switch),
+
+    # ── channel detail (classic page 2) ─────────────────────────────
+    "eq_enable":     GlobalParam("channel", "eq/enable", _to_switch, _from_switch),
+    "eq_gain_1":     GlobalParam("channel", "eq/band1gain", None, None),
+    "eq_gain_2":     GlobalParam("channel", "eq/band2gain", None, None),
+    "eq_gain_3":     GlobalParam("channel", "eq/band3gain", None, None),
+    "eq_freq_1":     GlobalParam("channel", "eq/band1freq", None, None),
+    "eq_freq_2":     GlobalParam("channel", "eq/band2freq", None, None),
+    "eq_freq_3":     GlobalParam("channel", "eq/band3freq", None, None),
+    "eq_q_1":        GlobalParam("channel", "eq/band1q", None, None),
+    "eq_q_2":        GlobalParam("channel", "eq/band2q", None, None),
+    "eq_q_3":        GlobalParam("channel", "eq/band3q", None, None),
+    "eq_type_1":     GlobalParam("channel", "eq/band1type", _enum4, _from_enum4),
+    "eq_type_3":     GlobalParam("channel", "eq/band3type", _enum4, _from_enum4),
+    "lowcut_enable": GlobalParam("channel", "lowcut/enable", _to_switch, _from_switch),
+    "lowcut_freq":   GlobalParam("channel", "lowcut/freq", None, None),
+    "lowcut_grade":  GlobalParam("channel", "lowcut/slope", None, None),
+    "dyn_enable":    GlobalParam("channel", "dynamics/enable", _to_switch, _from_switch),
+    "dyn_gain":      GlobalParam("channel", "dynamics/gain", *_dyn_gain),
+    "comp_thresh":   GlobalParam("channel", "dynamics/compthres", *_comp_thresh),
+    "comp_ratio":    GlobalParam("channel", "dynamics/compratio", *_ratio),
+    "exp_thresh":    GlobalParam("channel", "dynamics/expthres", *_exp_thresh),
+    "exp_ratio":     GlobalParam("channel", "dynamics/expratio", *_ratio),
+    "dyn_attack":    GlobalParam("channel", "dynamics/attack", *_attack),
+    "dyn_release":   GlobalParam("channel", "dynamics/release", *_release),
+    "alev_enable":   GlobalParam("channel", "autolevel/enable", _to_switch, _from_switch),
+    "alev_maxgain":  GlobalParam("channel", "autolevel/maxgain", *_alev_maxgain),
+    "alev_headroom": GlobalParam("channel", "autolevel/headroom", *_alev_headroom),
+    "alev_risetime": GlobalParam("channel", "autolevel/risetime", *_alev_risetime),
+    "input_gain":    GlobalParam("channel", "gain", None, None),
+    "input_gain_r":  GlobalParam("channel", "gain", None, None, lr=True),
+    "phase":         GlobalParam("channel", "phase", _to_switch, _from_switch),
+    "phase_r":       GlobalParam("channel", "phase", _to_switch, _from_switch, lr=True),
+
+    # ── global FX (classic page 3) ──────────────────────────────────
+    "reverb_enable":   GlobalParam("fx", "/reverb/enable", _to_switch, _from_switch),
+    "reverb_time":     GlobalParam("fx", "/reverb/time", None, None),
+    "reverb_volume":   GlobalParam("fx", "/reverb/volume", None, None),
+    "reverb_width":    GlobalParam("fx", "/reverb/width", None, None),
+    "reverb_predelay": GlobalParam("fx", "/reverb/predelay", None, None),
+    "echo_enable":     GlobalParam("fx", "/echo/enable", _to_switch, _from_switch),
+    "echo_time":       GlobalParam("fx", "/echo/delay", None, None),
+    "echo_feedback":   GlobalParam("fx", "/echo/feedback", None, None),
+    "echo_volume":     GlobalParam("fx", "/echo/volume", None, None),
+    "echo_width":      GlobalParam("fx", "/echo/width", None, None),
+}
+
+
+def calibrate(param: str, to_wire, from_wire):
+    """Install a measured transform (used by the calibration harness and
+    by hardware-round results as they land)."""
+    p = GLOBAL_PARAM_MAP[param]
+    p.to_wire, p.from_wire = to_wire, from_wire

--- a/global_units.py
+++ b/global_units.py
@@ -83,6 +83,21 @@ def _linear(lo, hi):
     return to_wire, from_wire
 
 
+def _log_map(lo, hi):
+    """Log-taper knob (freq params): classic 0.5 lands on sqrt(lo*hi) —
+    wire-measured 2026-08-21 (20..20000 Hz mid = 632, exactly sqrt)."""
+    import math
+    ratio = hi / lo
+
+    def to_wire(v):
+        return lo * (ratio ** _clamp01(v))
+
+    def from_wire(w):
+        return _clamp01(math.log(max(float(w), lo) / lo) / math.log(ratio))
+
+    return to_wire, from_wire
+
+
 def _enum4(v):
     """classic eq-type enum {0.0, 0.3333, 0.6667, 1.0} -> index 0..3"""
     return float(round(_clamp01(v) * 3.0))
@@ -116,6 +131,19 @@ class GlobalParam:
         return self.to_wire is not None
 
 
+# HW-5 wire-measured 2026-08-21 (classic 3-point sweeps, UFX II,
+# TotalMix 2.1 b5): EQ bands homogeneous (band1==band3 measured)
+_eq_gain = _linear(-20.0, 20.0)
+_eq_freq = _log_map(20.0, 20000.0)
+_eq_q = _linear(0.4, 9.9)
+_lowcut_freq = _log_map(20.0, 500.0)
+_fx_volume = _linear(-65.0, 6.0)
+_fx_width = _linear(0.0, 1.0)
+_reverb_time = _linear(0.1, 5.0)
+_reverb_predelay = _linear(0.0, 999.0)
+_echo_delay = _linear(0.1, 2.0)
+_echo_feedback = _linear(0.0, 100.0)
+
 _dyn_gain = _linear(-30.0, 30.0)
 _comp_thresh = _linear(-60.0, 0.0)
 _ratio = _linear(1.0, 10.0)
@@ -136,20 +164,20 @@ GLOBAL_PARAM_MAP = {
 
     # ── channel detail (classic page 2) ─────────────────────────────
     "eq_enable":     GlobalParam("channel", "eq/enable", _to_switch, _from_switch),
-    "eq_gain_1":     GlobalParam("channel", "eq/band1gain", None, None),
-    "eq_gain_2":     GlobalParam("channel", "eq/band2gain", None, None),
-    "eq_gain_3":     GlobalParam("channel", "eq/band3gain", None, None),
-    "eq_freq_1":     GlobalParam("channel", "eq/band1freq", None, None),
-    "eq_freq_2":     GlobalParam("channel", "eq/band2freq", None, None),
-    "eq_freq_3":     GlobalParam("channel", "eq/band3freq", None, None),
-    "eq_q_1":        GlobalParam("channel", "eq/band1q", None, None),
-    "eq_q_2":        GlobalParam("channel", "eq/band2q", None, None),
-    "eq_q_3":        GlobalParam("channel", "eq/band3q", None, None),
+    "eq_gain_1":     GlobalParam("channel", "eq/band1gain", *_eq_gain),
+    "eq_gain_2":     GlobalParam("channel", "eq/band2gain", *_eq_gain),
+    "eq_gain_3":     GlobalParam("channel", "eq/band3gain", *_eq_gain),
+    "eq_freq_1":     GlobalParam("channel", "eq/band1freq", *_eq_freq),
+    "eq_freq_2":     GlobalParam("channel", "eq/band2freq", *_eq_freq),
+    "eq_freq_3":     GlobalParam("channel", "eq/band3freq", *_eq_freq),
+    "eq_q_1":        GlobalParam("channel", "eq/band1q", *_eq_q),
+    "eq_q_2":        GlobalParam("channel", "eq/band2q", *_eq_q),
+    "eq_q_3":        GlobalParam("channel", "eq/band3q", *_eq_q),
     "eq_type_1":     GlobalParam("channel", "eq/band1type", _enum4, _from_enum4),
     "eq_type_3":     GlobalParam("channel", "eq/band3type", _enum4, _from_enum4),
     "lowcut_enable": GlobalParam("channel", "lowcut/enable", _to_switch, _from_switch),
-    "lowcut_freq":   GlobalParam("channel", "lowcut/freq", None, None),
-    "lowcut_grade":  GlobalParam("channel", "lowcut/slope", None, None),
+    "lowcut_freq":   GlobalParam("channel", "lowcut/freq", *_lowcut_freq),
+    "lowcut_grade":  GlobalParam("channel", "lowcut/slope", _enum4, _from_enum4),
     "dyn_enable":    GlobalParam("channel", "dynamics/enable", _to_switch, _from_switch),
     "dyn_gain":      GlobalParam("channel", "dynamics/gain", *_dyn_gain),
     "comp_thresh":   GlobalParam("channel", "dynamics/compthres", *_comp_thresh),
@@ -169,15 +197,15 @@ GLOBAL_PARAM_MAP = {
 
     # ── global FX (classic page 3) ──────────────────────────────────
     "reverb_enable":   GlobalParam("fx", "/reverb/enable", _to_switch, _from_switch),
-    "reverb_time":     GlobalParam("fx", "/reverb/time", None, None),
-    "reverb_volume":   GlobalParam("fx", "/reverb/volume", None, None),
-    "reverb_width":    GlobalParam("fx", "/reverb/width", None, None),
-    "reverb_predelay": GlobalParam("fx", "/reverb/predelay", None, None),
+    "reverb_time":     GlobalParam("fx", "/reverb/time", *_reverb_time),
+    "reverb_volume":   GlobalParam("fx", "/reverb/volume", *_fx_volume),
+    "reverb_width":    GlobalParam("fx", "/reverb/width", *_fx_width),
+    "reverb_predelay": GlobalParam("fx", "/reverb/predelay", *_reverb_predelay),
     "echo_enable":     GlobalParam("fx", "/echo/enable", _to_switch, _from_switch),
-    "echo_time":       GlobalParam("fx", "/echo/delay", None, None),
-    "echo_feedback":   GlobalParam("fx", "/echo/feedback", None, None),
-    "echo_volume":     GlobalParam("fx", "/echo/volume", None, None),
-    "echo_width":      GlobalParam("fx", "/echo/width", None, None),
+    "echo_time":       GlobalParam("fx", "/echo/delay", *_echo_delay),
+    "echo_feedback":   GlobalParam("fx", "/echo/feedback", *_echo_feedback),
+    "echo_volume":     GlobalParam("fx", "/echo/volume", *_fx_volume),
+    "echo_width":      GlobalParam("fx", "/echo/width", *_fx_width),
 }
 
 

--- a/mqtt_handler.py
+++ b/mqtt_handler.py
@@ -262,14 +262,19 @@ def setup_mqtt(client, mqtt_broker, mqtt_port, mqtt_user, mqtt_pass, osc_ip, osc
                     snap_num = int(payload)
                     if 1 <= snap_num <= 8:
                         osc_addr = f"/3/snapshots/{snapshot_num_to_osc_index(snap_num)}/1"
-                        t0 = time.time()
-                        send_osc(osc_addr, 1.0, osc_ip, osc_port)
-                        bridge.state_confirmed = bridge._wait_device(
-                            lambda st, addr=osc_addr: (
-                                st.raw.get(addr, {}).get("args") == [1.0]
-                                and st.raw.get(addr, {}).get("last_seen", 0) >= t0),
-                            timeout=1.0, fallback_sleep=0,
-                            what=f"MQTT snapshot #{snap_num} recall")
+                        if bridge._global_active():
+                            # #25: Global recall is 1-based + feedback-confirmed
+                            bridge.state_confirmed = bool(
+                                bridge.global_transport.load_snapshot(snap_num))
+                        else:
+                            t0 = time.time()
+                            send_osc(osc_addr, 1.0, osc_ip, osc_port)
+                            bridge.state_confirmed = bridge._wait_device(
+                                lambda st, addr=osc_addr: (
+                                    st.raw.get(addr, {}).get("args") == [1.0]
+                                    and st.raw.get(addr, {}).get("last_seen", 0) >= t0),
+                                timeout=1.0, fallback_sleep=0,
+                                what=f"MQTT snapshot #{snap_num} recall")
                         if bridge.state_confirmed:
                             bridge._layout_epoch = time.time()  # TASK-6 race hardening
                         logger.info(f"Snapshot #{snap_num} recalled ({osc_addr})")

--- a/mqtt_handler.py
+++ b/mqtt_handler.py
@@ -261,20 +261,18 @@ def setup_mqtt(client, mqtt_broker, mqtt_port, mqtt_user, mqtt_pass, osc_ip, osc
                 try:
                     snap_num = int(payload)
                     if 1 <= snap_num <= 8:
+                        # recall stays classic under every transport (#25
+                        # TASK 11: Global snapshot feedback unreliable;
+                        # classic button-echo confirm is 0.02-0.08s solid)
                         osc_addr = f"/3/snapshots/{snapshot_num_to_osc_index(snap_num)}/1"
-                        if bridge._global_active():
-                            # #25: Global recall is 1-based + feedback-confirmed
-                            bridge.state_confirmed = bool(
-                                bridge.global_transport.load_snapshot(snap_num))
-                        else:
-                            t0 = time.time()
-                            send_osc(osc_addr, 1.0, osc_ip, osc_port)
-                            bridge.state_confirmed = bridge._wait_device(
-                                lambda st, addr=osc_addr: (
-                                    st.raw.get(addr, {}).get("args") == [1.0]
-                                    and st.raw.get(addr, {}).get("last_seen", 0) >= t0),
-                                timeout=1.0, fallback_sleep=0,
-                                what=f"MQTT snapshot #{snap_num} recall")
+                        t0 = time.time()
+                        send_osc(osc_addr, 1.0, osc_ip, osc_port)
+                        bridge.state_confirmed = bridge._wait_device(
+                            lambda st, addr=osc_addr: (
+                                st.raw.get(addr, {}).get("args") == [1.0]
+                                and st.raw.get(addr, {}).get("last_seen", 0) >= t0),
+                            timeout=1.0, fallback_sleep=0,
+                            what=f"MQTT snapshot #{snap_num} recall")
                         if bridge.state_confirmed:
                             bridge._layout_epoch = time.time()  # TASK-6 race hardening
                         logger.info(f"Snapshot #{snap_num} recalled ({osc_addr})")

--- a/tests/test_global_transport.py
+++ b/tests/test_global_transport.py
@@ -176,7 +176,8 @@ def test_unknown_param_refused(rig):
 
 def test_uncalibrated_param_refused(rig):
     tr, client, *_ = rig
-    w, _, status = tr.resolve_step({"channel": "Mic 1", "param": "eq_gain_1"})
+    # input_gain is the one param still awaiting a wire calibration
+    w, _, status = tr.resolve_step({"channel": "Mic 1", "param": "input_gain"})
     assert (w, status) == (None, "uncalibrated_param")
     assert client.sent == []  # refusal means nothing hits the wire
 

--- a/tests/test_global_transport.py
+++ b/tests/test_global_transport.py
@@ -1,0 +1,298 @@
+"""Global transport (#25) — resolution, writers, sync, liveness. No UDP:
+feedback is fed straight into the listener state via ingest()."""
+import importlib
+import os
+
+import pytest
+
+import global_transport as gt
+import physical_table as pt
+from global_listener import GlobalOSCListener
+
+
+class FakeClient:
+    def __init__(self):
+        self.sent = []
+
+    def send_message(self, address, value):
+        self.sent.append((address, value))
+
+
+def make_table():
+    t = pt.empty_table()
+    for hw, name in ((0, "Mic 1"), (2, "AN 1/2"), (3, "AN 1/2"), (6, "SPDIF")):
+        pt.merge_observation(t, "inputs", hw, name)
+    pt.merge_observation(t, "inputs", 2, "AN 1")
+    pt.merge_observation(t, "inputs", 3, "AN 2")
+    for hw, name in ((0, "Main"), (0, "AN 1/2"), (4, "Phones")):
+        pt.merge_observation(t, "outputs", hw, name)
+    pt.merge_observation(t, "playbacks", 0, "Out 1")
+    return t
+
+
+@pytest.fixture
+def rig():
+    client = FakeClient()
+    listener = GlobalOSCListener(0)  # never started — state fed directly
+    table = make_table()
+    persists = []
+    tr = gt.GlobalTransport(client, listener, lambda: table,
+                            persist_cb=lambda: persists.append(1))
+    return tr, client, listener, table, persists
+
+
+# ── resolution + writers ───────────────────────────────────────────
+
+def test_volume_send_resolves_to_mix_address(rig):
+    tr, client, *_ = rig
+    w, label, status = tr.resolve_step(
+        {"channel": "Mic 1", "submix": "Phones", "param": "volume"})
+    assert status == "resolved"
+    assert w.address == "/mix/in/0/4/faderlin"
+    w.send_message("x", 0.5)
+    assert client.sent == [("/mix/in/0/4/faderlin", 0.5)]  # identity (HW-2)
+
+
+def test_playback_row_uses_pb_source(rig):
+    tr, *_ = rig
+    w, _, status = tr.resolve_step(
+        {"channel": "Out 1", "submix": "Main", "row": 2, "param": "volume"})
+    assert status == "resolved"
+    assert w.address == "/mix/pb/0/0/faderlin"
+
+
+def test_row3_volume_is_output_fader(rig):
+    tr, *_ = rig
+    w, _, status = tr.resolve_step(
+        {"channel": "Phones", "row": 3, "param": "volume"})
+    assert status == "resolved"
+    assert w.address == "/output/4/faderlin"
+
+
+def test_pan_converts_to_balpan(rig):
+    tr, client, *_ = rig
+    w, _, status = tr.resolve_step(
+        {"channel": "Mic 1", "submix": "Main", "param": "pan"})
+    assert status == "resolved"
+    assert w.address == "/mix/in/0/0/balpan"
+    w.send_message("x", 0.0)
+    w.send_message("x", 1.0)
+    assert client.sent == [("/mix/in/0/0/balpan", -1.0),
+                           ("/mix/in/0/0/balpan", 1.0)]
+
+
+def test_mute_is_channel_scoped_switch(rig):
+    tr, client, *_ = rig
+    w, _, status = tr.resolve_step({"channel": "SPDIF", "param": "mute"})
+    assert status == "resolved"
+    assert w.address == "/input/6/mute"
+    w.send_message("x", 0.8)
+    w.send_message("x", 0.2)
+    assert client.sent == [("/input/6/mute", 1.0), ("/input/6/mute", 0.0)]
+
+
+def test_lr_param_addresses_right_member(rig):
+    tr, *_ = rig
+    w, _, status = tr.resolve_step({"channel": "AN 1/2", "param": "phase_r"})
+    assert status == "resolved"
+    assert w.address == "/input/3/phase"  # pair start 2 → right member 3
+
+
+def test_fx_param_needs_no_channel(rig):
+    tr, client, *_ = rig
+    w, _, status = tr.resolve_step({"param": "reverb_enable"})
+    assert status == "resolved"
+    assert w.address == "/reverb/enable"
+    w.send_message("x", 1.0)
+    assert client.sent == [("/reverb/enable", 1.0)]
+
+
+def test_mono_name_hits_own_channel_when_unlinked(rig):
+    tr, *_ = rig
+    w, _, status = tr.resolve_step(
+        {"channel": "AN 2", "submix": "Main", "param": "volume"})
+    assert status == "resolved"
+    assert w.address == "/mix/in/3/0/faderlin"  # its own hardware channel
+
+
+def test_mono_name_defaults_to_pair_when_linked(rig):
+    tr, _, listener, *_ = rig
+    listener.state.ingest("/input/2/stereo", (1.0,))  # pair (2,3) linked now
+    w, _, status = tr.resolve_step(
+        {"channel": "AN 2", "submix": "Main", "param": "volume"})
+    assert status == "resolved"
+    # right member isn't an addressable strip while linked → pair start
+    assert w.address == "/mix/in/2/0/faderlin"
+
+
+def test_pair_name_resolves_to_start(rig):
+    tr, *_ = rig
+    w, _, status = tr.resolve_step(
+        {"channel": "AN 1/2", "submix": "Main", "param": "volume"})
+    assert status == "resolved"
+    assert w.address == "/mix/in/2/0/faderlin"
+
+
+def test_live_names_take_precedence_over_table(rig):
+    tr, _, listener, *_ = rig
+    # snapshot renamed hw 6 to "Pill" — table has no such alias yet
+    listener.state.ingest("/input/6/name", ("Pill",))
+    w, _, status = tr.resolve_step(
+        {"channel": "Pill", "submix": "Main", "param": "volume"})
+    assert status == "resolved"
+    assert w.address == "/mix/in/6/0/faderlin"
+
+
+# ── refusals ───────────────────────────────────────────────────────
+
+def test_unknown_channel_refused(rig):
+    tr, client, *_ = rig
+    w, label, status = tr.resolve_step(
+        {"channel": "Nope", "submix": "Main", "param": "volume"})
+    assert (w, status) == (None, "not_in_table")
+    assert label == "Nope"
+    assert client.sent == []
+
+
+def test_unknown_submix_refused(rig):
+    tr, *_ = rig
+    w, label, status = tr.resolve_step(
+        {"channel": "Mic 1", "submix": "Nope", "param": "volume"})
+    assert (w, status) == (None, "not_in_table")
+    assert label == "Nope"
+
+
+def test_volume_without_submix_refused(rig):
+    tr, *_ = rig
+    w, _, status = tr.resolve_step({"channel": "Mic 1", "param": "volume"})
+    assert (w, status) == (None, "not_in_table")
+
+
+def test_unknown_param_refused(rig):
+    tr, *_ = rig
+    w, _, status = tr.resolve_step({"channel": "Mic 1", "param": "warp"})
+    assert (w, status) == (None, "unsupported_param")
+
+
+def test_uncalibrated_param_refused(rig):
+    tr, client, *_ = rig
+    w, _, status = tr.resolve_step({"channel": "Mic 1", "param": "eq_gain_1"})
+    assert (w, status) == (None, "uncalibrated_param")
+    assert client.sent == []  # refusal means nothing hits the wire
+
+
+def test_playback_row_has_no_channel_detail(rig):
+    tr, *_ = rig
+    w, _, status = tr.resolve_step(
+        {"channel": "Out 1", "row": 2, "param": "eq_enable"})
+    assert (w, status) == (None, "playback_no_detail")
+
+
+def test_playback_mute_is_allowed(rig):
+    tr, *_ = rig
+    w, _, status = tr.resolve_step(
+        {"channel": "Out 1", "row": 2, "param": "mute"})
+    assert status == "resolved"
+    assert w.address == "/playback/0/mute"
+
+
+# ── snapshot + liveness ────────────────────────────────────────────
+
+def test_load_snapshot_sends_and_confirms(rig):
+    tr, client, listener, *_ = rig
+    listener.state.ingest("/snapshot/load/3", (2.0,))  # device: slot 3 active
+    assert tr.load_snapshot(3) is True
+    assert client.sent == [("/snapshot/load/3", 1.0)]  # 1-BASED, no 9-N
+
+
+def test_load_snapshot_times_out_without_feedback(rig):
+    tr, *_ = rig
+    assert tr.load_snapshot(5, timeout=0.05) is False
+
+
+def test_alive_via_fresh_heartbeat(rig):
+    tr, client, listener, *_ = rig
+    listener.state.ingest("/status/device", (1.0,))
+    r = tr.alive()
+    assert r["alive"] is True and r["method"] == "heartbeat"
+    assert client.sent == []  # no probe traffic needed
+
+
+def test_alive_probes_with_sendstate_when_stale(rig):
+    tr, client, listener, *_ = rig
+    listener.wait_for = lambda pred, timeout: False  # nothing ever arrives
+    r = tr.alive()
+    assert r["alive"] is False
+    assert ("/sendstate", 1.0) in client.sent
+
+
+# ── name sync → physical table ─────────────────────────────────────
+
+def test_name_sync_merges_and_mirrors_stereo_pair(rig):
+    tr, _, listener, table, persists = rig
+    listener.state.ingest("/input/2/name", ("Pill Out",))
+    listener.state.ingest("/input/2/stereo", (1.0,))
+    assert tr.sync_names_once() == 2  # left member + mirrored right member
+    assert pt.resolve_start(table, "inputs", "Pill Out") == 2
+    assert pt.covers(table, "inputs", 3, "AN 2", "Pill Out")
+    assert persists == [1]
+    assert tr.sync_names_once() == 0  # drained — no re-merge, no re-persist
+    assert persists == [1]
+
+
+def test_name_sync_mono_channel_merges_once(rig):
+    tr, _, listener, table, persists = rig
+    listener.state.ingest("/input/6/name", ("Sync L",))
+    assert tr.sync_names_once() == 1
+    assert pt.resolve_start(table, "inputs", "Sync L") == 6
+    assert not pt.covers(table, "inputs", 7, "Sync L", "Sync L")
+
+
+def test_name_sync_known_alias_is_noop(rig):
+    tr, _, listener, table, persists = rig
+    listener.state.ingest("/input/0/name", ("Mic 1",))
+    assert tr.sync_names_once() == 0
+    assert persists == []
+
+
+# ── lifecycle ──────────────────────────────────────────────────────
+
+def test_start_bootstraps_with_sendall_and_stop_joins(rig):
+    tr, client, *_ = rig
+    tr.start()
+    try:
+        assert ("/sendall", 1.0) in client.sent
+        assert tr._sync_thread.is_alive()
+    finally:
+        tr.stop()
+    assert tr._sync_thread is None
+
+
+# ── config selection (WI-6) ────────────────────────────────────────
+
+def test_config_transport_selection(monkeypatch):
+    import config
+    monkeypatch.delenv("OSC_TRANSPORT", raising=False)
+    monkeypatch.delenv("ENABLE_GLOBAL_OSC_LISTENER", raising=False)
+    importlib.reload(config)
+    assert config.OSC_TRANSPORT == "classic"
+    assert config.ENABLE_GLOBAL_OSC_LISTENER is False
+    assert config.GLOBAL_OSC_PORT == 7002
+    assert config.GLOBAL_OSC_LISTEN_PORT == 9002
+
+    monkeypatch.setenv("OSC_TRANSPORT", "global")
+    importlib.reload(config)
+    assert config.OSC_TRANSPORT == "global"
+    # selecting the global transport implies its listener
+    assert config.ENABLE_GLOBAL_OSC_LISTENER is True
+
+    monkeypatch.setenv("OSC_TRANSPORT", "classic")
+    monkeypatch.setenv("ENABLE_GLOBAL_OSC_LISTENER", "true")
+    importlib.reload(config)
+    # shadow mode: classic writes, global listener observing
+    assert config.OSC_TRANSPORT == "classic"
+    assert config.ENABLE_GLOBAL_OSC_LISTENER is True
+
+    monkeypatch.delenv("OSC_TRANSPORT", raising=False)
+    monkeypatch.delenv("ENABLE_GLOBAL_OSC_LISTENER", raising=False)
+    importlib.reload(config)

--- a/tests/test_global_units.py
+++ b/tests/test_global_units.py
@@ -1,0 +1,63 @@
+"""global_units — the RME fader curve (spec-fixed points) + transforms."""
+import pytest
+
+import global_units as gu
+
+
+def test_fader_curve_spec_fixed_points():
+    assert gu.fader_db(1.0) == pytest.approx(6.0, abs=0.01)          # top = +6 dB
+    assert gu.fader_db(649.0 / 1023.0) == pytest.approx(-6.0, abs=0.01)  # breakpoint
+    assert gu.fader_db(0.5) == pytest.approx(-12.13, abs=0.05)       # spec curve
+    assert gu.fader_db(0.0) == gu.GAIN_SUBMIX_OFF                    # floor = off
+
+
+def test_fader_curve_round_trips():
+    for x in (0.2, 0.4, 0.634, 0.75, 0.9, 1.0):
+        assert gu.fader_lin(gu.fader_db(x)) == pytest.approx(x, abs=0.002)
+    assert gu.fader_lin(-6.0) == pytest.approx(649.0 / 1023.0, abs=0.001)
+    assert gu.fader_lin(gu.GAIN_SUBMIX_OFF) == 0.0
+    assert gu.fader_lin(99.0) == 1.0                                 # clamped
+
+
+def test_measured_linear_transforms():
+    m = gu.GLOBAL_PARAM_MAP
+    assert m["dyn_gain"].to_wire(0.5) == pytest.approx(0.0)          # -30..+30 dB
+    assert m["comp_thresh"].to_wire(0.0) == pytest.approx(-60.0)
+    assert m["comp_ratio"].to_wire(1.0) == pytest.approx(10.0)
+    assert m["alev_headroom"].to_wire(1.0) == pytest.approx(12.0)    # 3..12 dB
+    # round trips
+    for p in ("dyn_gain", "exp_thresh", "dyn_attack", "alev_risetime"):
+        assert m[p].from_wire(m[p].to_wire(0.3)) == pytest.approx(0.3)
+
+
+def test_switches_pan_and_enums():
+    m = gu.GLOBAL_PARAM_MAP
+    assert m["mute"].to_wire(0.9) == 1.0 and m["mute"].to_wire(0.1) == 0.0
+    assert m["pan"].to_wire(0.0) == -1.0 and m["pan"].to_wire(1.0) == 1.0
+    assert m["pan"].to_wire(0.5) == pytest.approx(0.0)
+    assert m["eq_type_1"].to_wire(0.6667) == 2.0                     # High Pass
+    assert m["eq_type_1"].from_wire(3.0) == pytest.approx(1.0)
+
+
+def test_uncalibrated_params_are_marked_and_refusable():
+    m = gu.GLOBAL_PARAM_MAP
+    for p in ("eq_gain_1", "eq_freq_2", "lowcut_freq", "input_gain",
+              "reverb_time", "echo_feedback"):
+        assert not m[p].calibrated
+    assert m["volume"].calibrated and m["mute"].calibrated
+
+
+def test_lr_params_flagged():
+    m = gu.GLOBAL_PARAM_MAP
+    assert m["input_gain_r"].lr and m["phase_r"].lr
+    assert not m["input_gain"].lr and not m["phase"].lr
+
+
+def test_calibrate_installs_transform():
+    gu.calibrate("lowcut_freq", *gu._linear(20.0, 500.0))
+    try:
+        assert gu.GLOBAL_PARAM_MAP["lowcut_freq"].calibrated
+        assert gu.GLOBAL_PARAM_MAP["lowcut_freq"].to_wire(0.0) == 20.0
+    finally:
+        gu.GLOBAL_PARAM_MAP["lowcut_freq"].to_wire = None
+        gu.GLOBAL_PARAM_MAP["lowcut_freq"].from_wire = None

--- a/tests/test_global_units.py
+++ b/tests/test_global_units.py
@@ -40,11 +40,35 @@ def test_switches_pan_and_enums():
 
 
 def test_uncalibrated_params_are_marked_and_refusable():
+    # only the preamp gain remains unmeasured (audible-risk sweep deferred;
+    # digital channels have no gain param at all)
     m = gu.GLOBAL_PARAM_MAP
-    for p in ("eq_gain_1", "eq_freq_2", "lowcut_freq", "input_gain",
-              "reverb_time", "echo_feedback"):
-        assert not m[p].calibrated
+    assert not m["input_gain"].calibrated
+    assert not m["input_gain_r"].calibrated
     assert m["volume"].calibrated and m["mute"].calibrated
+
+
+def test_hw5_measured_calibrations():
+    """Wire-measured 2026-08-21 (classic 3-point sweeps on the UFX II)."""
+    m = gu.GLOBAL_PARAM_MAP
+    assert m["eq_gain_1"].to_wire(0.0) == -20.0
+    assert m["eq_gain_1"].to_wire(1.0) == 20.0
+    assert m["eq_gain_2"].to_wire(0.5) == pytest.approx(0.0)
+    # freq knobs are LOG taper: classic 0.5 measured at 632 Hz = sqrt(20*20k)
+    assert m["eq_freq_1"].to_wire(0.5) == pytest.approx(632.455, abs=0.01)
+    assert m["eq_freq_1"].to_wire(0.0) == pytest.approx(20.0)
+    assert m["eq_freq_1"].to_wire(1.0) == pytest.approx(20000.0)
+    assert m["eq_freq_1"].from_wire(632.455) == pytest.approx(0.5, abs=1e-4)
+    assert m["eq_q_1"].to_wire(0.0) == pytest.approx(0.4)
+    assert m["eq_q_1"].to_wire(1.0) == pytest.approx(9.9)
+    assert m["lowcut_freq"].to_wire(0.5) == pytest.approx(100.0)  # sqrt(20*500)
+    assert m["lowcut_grade"].to_wire(1.0) == 3.0                  # enum 0..3
+    assert m["reverb_time"].to_wire(0.5) == pytest.approx(2.55)
+    assert m["reverb_volume"].to_wire(0.5) == pytest.approx(-29.5)
+    assert m["reverb_predelay"].to_wire(1.0) == pytest.approx(999.0)
+    assert m["echo_time"].to_wire(1.0) == pytest.approx(2.0)
+    assert m["echo_feedback"].to_wire(0.5) == pytest.approx(50.0)
+    assert m["echo_width"].to_wire(0.5) == pytest.approx(0.5)
 
 
 def test_lr_params_flagged():
@@ -54,10 +78,10 @@ def test_lr_params_flagged():
 
 
 def test_calibrate_installs_transform():
-    gu.calibrate("lowcut_freq", *gu._linear(20.0, 500.0))
+    gu.calibrate("input_gain", *gu._linear(0.0, 75.0))
     try:
-        assert gu.GLOBAL_PARAM_MAP["lowcut_freq"].calibrated
-        assert gu.GLOBAL_PARAM_MAP["lowcut_freq"].to_wire(0.0) == 20.0
+        assert gu.GLOBAL_PARAM_MAP["input_gain"].calibrated
+        assert gu.GLOBAL_PARAM_MAP["input_gain"].to_wire(0.0) == 0.0
     finally:
-        gu.GLOBAL_PARAM_MAP["lowcut_freq"].to_wire = None
-        gu.GLOBAL_PARAM_MAP["lowcut_freq"].from_wire = None
+        gu.GLOBAL_PARAM_MAP["input_gain"].to_wire = None
+        gu.GLOBAL_PARAM_MAP["input_gain"].from_wire = None

--- a/tests/test_mqtt_handler.py
+++ b/tests/test_mqtt_handler.py
@@ -48,6 +48,9 @@ class FakeBridge:
         self.wait_device_calls.append(what)
         return True
 
+    def _global_active(self):
+        return False  # classic transport (#25 seam)
+
     def run_macro(self, name, param):
         self.run_macro_calls.append((name, param))
 

--- a/tests/test_transport_selection.py
+++ b/tests/test_transport_selection.py
@@ -110,18 +110,17 @@ def test_ramp_operation_runs_through_global_writer(global_rig, fake_osc):
     assert fake_osc.sent == []
 
 
-def test_snapshot_switch_uses_global_recall(global_rig, fake_osc):
-    b, gclient, listener = global_rig({"go": {
+def test_snapshot_and_workspace_stay_classic_under_global(global_rig,
+                                                          fake_osc):
+    # TASK 11 finding 1: Global /snapshot/load feedback is unreliable in
+    # 2.1 b5, so BOTH switch kinds stay on the classic remote even when
+    # the global transport does the param writing
+    b, gclient, _ = global_rig({"go": {
         "workspace": "Pill_setup", "snapshot": "Reset",
         "steps": []}})
-    # device will confirm slot 1 active
-    listener.state.ingest("/snapshot/load/1", (2.0,))
     b.run_macro("go", 0.5)
-    # workspace switching has no Global equivalent — stays classic
     assert ("/loadQuickWorkspace", 2.0) in fake_osc.sent
-    # snapshot recall is Global: 1-based, no 9-N inversion
-    assert ("/snapshot/load/1", 1.0) in gclient.sent
-    assert not [a for a in fake_osc.addresses()
-                if a.startswith("/3/snapshots")]
-    assert b.state_confirmed is True
+    assert ("/3/snapshots/8/1", 1.0) in fake_osc.sent  # slot 1 → 9-N index 8
+    assert not [a for a in gclient.addresses()
+                if a.startswith("/snapshot/load")]
     assert b.current_snapshot == "reset"

--- a/tests/test_transport_selection.py
+++ b/tests/test_transport_selection.py
@@ -82,7 +82,7 @@ def test_global_refusal_emits_skip_event(global_rig, fake_osc):
 
 def test_uncalibrated_param_refused_end_to_end(global_rig, fake_osc):
     b, gclient, _ = global_rig({"eq": {"steps": [{
-        "target": {"channel": "Mic 1", "param": "eq_gain_1"},
+        "target": {"channel": "Mic 1", "param": "input_gain"},
         "value": "{{param}}"}]}})
     b.run_macro("eq", 0.5)
     assert _skips(b) == ["target_uncalibrated_param"]

--- a/tests/test_transport_selection.py
+++ b/tests/test_transport_selection.py
@@ -1,0 +1,127 @@
+"""#25: run_macro routing between the classic and Global transports.
+The Global transport gets its own fake client so tests can assert which
+wire each write went out on."""
+import pytest
+
+import bridge as bridge_mod
+import physical_table as pt
+from global_listener import GlobalOSCListener
+from global_transport import GlobalTransport
+
+
+class FakeGlobalClient:
+    def __init__(self):
+        self.sent = []
+
+    def send_message(self, address, value):
+        self.sent.append((address, value))
+
+    def addresses(self):
+        return [a for a, _ in self.sent]
+
+
+@pytest.fixture
+def global_rig(make_bridge, monkeypatch):
+    """Bridge with an attached (unstarted) Global transport, selected via
+    OSC_TRANSPORT=global."""
+    def _make(macros):
+        b = make_bridge(macros)
+        table = pt.empty_table()
+        pt.merge_observation(table, "inputs", 0, "Mic 1")
+        pt.merge_observation(table, "outputs", 4, "Phones")
+        b.channel_map = {"physical_table": table}
+        gclient = FakeGlobalClient()
+        listener = GlobalOSCListener(0)  # never started — state fed directly
+        b.global_transport = GlobalTransport(
+            gclient, listener, b._physical_table)
+        monkeypatch.setattr(bridge_mod, "OSC_TRANSPORT", "global")
+        return b, gclient, listener
+    return _make
+
+
+TARGET_MACRO = {
+    "steps": [{
+        "target": {"channel": "Mic 1", "submix": "Phones", "param": "volume"},
+        "value": "{{param}}",
+    }],
+}
+
+
+def _skips(b):
+    return [e["event"]["reason"] for e in b.events
+            if e["event"] and e["event"]["type"] == "macro_skipped"]
+
+
+def test_target_step_routes_to_global_wire(global_rig, fake_osc):
+    b, gclient, _ = global_rig({"vol": TARGET_MACRO})
+    b.run_macro("vol", 0.7)
+    assert ("/mix/in/0/4/faderlin", 0.7) in gclient.sent
+    # nothing classic: no aiming, no restores, no writes
+    assert fake_osc.sent == []
+
+
+def test_classic_default_ignores_attached_transport(global_rig, monkeypatch,
+                                                    fake_osc):
+    b, gclient, _ = global_rig({"vol": TARGET_MACRO})
+    monkeypatch.setattr(bridge_mod, "OSC_TRANSPORT", "classic")
+    assert b._global_active() is False
+    b.run_macro("vol", 0.7)
+    # classic resolution has no feedback in tests → step skipped, but the
+    # decisive assertion is that the GLOBAL wire stayed silent
+    assert gclient.sent == []
+
+
+def test_global_refusal_emits_skip_event(global_rig, fake_osc):
+    b, gclient, _ = global_rig({"bad": {"steps": [{
+        "target": {"channel": "Ghost", "submix": "Phones", "param": "volume"},
+        "value": "{{param}}"}]}})
+    b.run_macro("bad", 0.5)
+    assert _skips(b) == ["target_not_in_table"]
+    assert gclient.sent == [] and fake_osc.sent == []
+
+
+def test_uncalibrated_param_refused_end_to_end(global_rig, fake_osc):
+    b, gclient, _ = global_rig({"eq": {"steps": [{
+        "target": {"channel": "Mic 1", "param": "eq_gain_1"},
+        "value": "{{param}}"}]}})
+    b.run_macro("eq", 0.5)
+    assert _skips(b) == ["target_uncalibrated_param"]
+    assert gclient.sent == []
+
+
+def test_raw_osc_step_stays_on_classic_wire(global_rig, fake_osc):
+    b, gclient, _ = global_rig({"raw": {"steps": [
+        {"osc": "/1/mastermute", "value": 1.0}]}})
+    b.run_macro("raw", 0.5)
+    assert ("/1/mastermute", 1.0) in fake_osc.sent
+    assert gclient.sent == []
+
+
+def test_ramp_operation_runs_through_global_writer(global_rig, fake_osc):
+    b, gclient, _ = global_rig({"ramp": {"steps": [{
+        "target": {"channel": "Mic 1", "submix": "Phones", "param": "volume"},
+        "value": "{{param}}",
+        "operation": {"type": "ramp", "bars": 1, "bpm": 600,
+                      "steps_per_beat": 4, "curve": "linear"}}]}})
+    b.run_macro("ramp", 1.0)
+    addrs = set(gclient.addresses())
+    assert addrs == {"/mix/in/0/4/faderlin"}
+    assert len(gclient.sent) > 3          # a stream, not a single set
+    assert fake_osc.sent == []
+
+
+def test_snapshot_switch_uses_global_recall(global_rig, fake_osc):
+    b, gclient, listener = global_rig({"go": {
+        "workspace": "Pill_setup", "snapshot": "Reset",
+        "steps": []}})
+    # device will confirm slot 1 active
+    listener.state.ingest("/snapshot/load/1", (2.0,))
+    b.run_macro("go", 0.5)
+    # workspace switching has no Global equivalent — stays classic
+    assert ("/loadQuickWorkspace", 2.0) in fake_osc.sent
+    # snapshot recall is Global: 1-based, no 9-N inversion
+    assert ("/snapshot/load/1", 1.0) in gclient.sent
+    assert not [a for a in fake_osc.addresses()
+                if a.startswith("/3/snapshots")]
+    assert b.state_confirmed is True
+    assert b.current_snapshot == "reset"

--- a/tools/global_hw_gates.py
+++ b/tools/global_hw_gates.py
@@ -1,0 +1,371 @@
+"""#25 hardware gates HW-3/5/6/8 (+ final snapshot wash = HW-7).
+
+Runs on the TotalMix host. Every gate restores what it changes; the final
+`wash` recalls the active snapshot, which also restores any snapshot-scoped
+residue (verify it reads 2.0 = active/unmodified BEFORE the session so the
+wash is a true restore).
+
+Calibration method (HW-5): the classic remote writes the normalized 0..1
+endpoints+midpoint of a param, the Global listener reads the REAL wire
+units TotalMix broadcasts on change ('Send changes' is ON for the Global
+remote, and classic-originated changes are 'changes'). Three points
+determine lo/hi and linear-vs-log. Channel params aim classic page 2 via
+/setBankStart <hw> (page 2 mirrors the BANK-START channel), self-verified
+on the Global side, bank restored to 0 after.
+
+Safety: no /setSubmix anywhere; typed floats only; FX must be DISABLED
+before calfx (checked); channel gates default to unused ADAT inputs.
+"""
+import argparse
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from pythonosc.udp_client import SimpleUDPClient
+
+import global_units as gu
+from global_listener import GlobalOSCListener
+
+HOST = os.getenv("GLOBAL_OSC_IP", "192.168.1.61")
+GLOBAL_PORT = int(os.getenv("GLOBAL_OSC_PORT", "7002"))
+LISTEN_PORT = int(os.getenv("GLOBAL_OSC_LISTEN_PORT", "9002"))
+CLASSIC_PORT = int(os.getenv("OSC_PORT", "7001"))
+
+
+class Rig:
+    def __init__(self):
+        self.g = SimpleUDPClient(HOST, GLOBAL_PORT)
+        self.c = SimpleUDPClient(HOST, CLASSIC_PORT)
+        self.rx = GlobalOSCListener(LISTEN_PORT)
+        if not self.rx.start():
+            sys.exit("listener bind failed")
+
+    def stop(self):
+        self.rx.stop()
+
+    # ── reads (feedback-driven) ────────────────────────────────────
+    def wait_param(self, row_key, hw, path, t0, timeout=3.0):
+        ok = self.rx.wait_for(
+            lambda s: (s.get_param(row_key, hw, path) or (None, 0))[1] > t0,
+            timeout)
+        e = self.rx.state.get_param(row_key, hw, path)
+        return (e[0] if e else None), ok
+
+    def rechan(self, row, hw):
+        """Targeted re-dump of one channel; returns after the burst."""
+        t0 = time.time()
+        self.g.send_message(f"/sendchan/{row}/{hw}", 1.0)
+        row_key = {"input": "inputs", "playback": "playbacks",
+                   "output": "outputs"}[row]
+        self.rx.wait_for(
+            lambda s: (s.get_param(row_key, hw, "mute") or (None, 0))[1] > t0,
+            3.0)
+        time.sleep(0.25)   # let the rest of the burst land
+
+    def read_chan(self, row, hw, path):
+        self.rechan(row, hw)
+        row_key = {"input": "inputs", "playback": "playbacks",
+                   "output": "outputs"}[row]
+        e = self.rx.state.get_param(row_key, hw, path)
+        return e[0] if e else None
+
+    def read_mix(self, src, in_hw, out_hw, param, timeout=10.0):
+        """/sendmix re-dump (own Global writes never echo), then read."""
+        t0 = time.time()
+        self.g.send_message("/sendmix", 1.0)
+        self.rx.wait_for(
+            lambda s: (s.get_mix(src, in_hw, out_hw, param) or (None, 0))[1] > t0,
+            timeout)
+        e = self.rx.state.get_mix(src, in_hw, out_hw, param)
+        return e[0] if e else None
+
+    def classic_3point(self, classic_addr, read_after):
+        """Write 0 / 0.5 / 1 on the classic port, read real units after
+        each via read_after(t0) -> (value, arrived)."""
+        pts = []
+        for v in (0.0, 0.5, 1.0):
+            t0 = time.time()
+            self.c.send_message(classic_addr, float(v))
+            val, ok = read_after(t0)
+            pts.append((v, val if ok else None))
+            time.sleep(0.15)
+        return pts
+
+
+def curve_verdict(pts):
+    (_, lo), (_, mid), (_, hi) = pts
+    if None in (lo, mid, hi):
+        return "NO-FEEDBACK", lo, hi
+    if hi == lo:
+        return "CONSTANT", lo, hi
+    lin_mid = (lo + hi) / 2.0
+    verdict = "linear" if abs(mid - lin_mid) <= 0.02 * abs(hi - lo) else "NONLINEAR"
+    if verdict == "NONLINEAR" and lo > 0 and hi > 0:
+        import math
+        log_mid = math.sqrt(lo * hi)
+        if abs(mid - log_mid) <= 0.05 * abs(hi - lo):
+            verdict = "log"
+    return verdict, lo, hi
+
+
+# ── HW-3: are Global enables absolute sets? ────────────────────────
+def gate_enables(rig, args):
+    hw, path = args.ch, "eq/enable"
+    addr = f"/input/{hw}/{path}"
+    orig = rig.read_chan("input", hw, path)
+    print(f"orig {path} = {orig}")
+    seq = []
+    for v in (1.0, 1.0, 0.0, 0.0):        # repeat-writes expose toggles
+        rig.g.send_message(addr, v)
+        time.sleep(0.15)
+        seq.append((v, rig.read_chan("input", hw, path)))
+        print(f"  wrote {v} -> read {seq[-1][1]}")
+    absolute = [s[1] for s in seq] == [1.0, 1.0, 0.0, 0.0]
+    rig.g.send_message(addr, float(orig))
+    time.sleep(0.15)
+    restored = rig.read_chan("input", hw, path)
+    print(f"restored -> {restored} (orig {orig})")
+    print("HW-3: ABSOLUTE SET — PASS" if absolute else
+          "HW-3: NOT ABSOLUTE (momentary/toggle?) — FAIL, transport needs "
+          "edge handling")
+
+
+# ── HW-6: balpan write path + range ────────────────────────────────
+def gate_pan(rig, args):
+    src, i, o = "in", args.in_ch, args.out_ch
+    addr = f"/mix/{src}/{i}/{o}/balpan"
+    orig = rig.read_mix(src, i, o, "balpan")
+    print(f"orig balpan {i}->{o} = {orig}")
+    if orig is None:
+        print("HW-6: no balpan entry in /sendmix — FAIL/investigate")
+        return
+    results = []
+    for v in (-1.0, 1.0, 0.5, 0.0):
+        rig.g.send_message(addr, v)
+        time.sleep(0.15)
+        rb = rig.read_mix(src, i, o, "balpan")
+        results.append((v, rb))
+        print(f"  wrote {v} -> readback {rb}")
+    rig.g.send_message(addr, float(orig))
+    time.sleep(0.15)
+    print(f"restored -> {rig.read_mix(src, i, o, 'balpan')} (orig {orig})")
+    ok = all(rb is not None and abs(rb - v) < 0.02 for v, rb in results)
+    print("HW-6: balpan -1..+1 accepted & echoed exactly — PASS" if ok
+          else f"HW-6: mismatch {results} — FAIL")
+
+
+# ── HW-8: linked-pair addressing ───────────────────────────────────
+def gate_stereo(rig, args):
+    left = args.left
+    right = left + 1
+    rig.rechan("input", left)
+    st = rig.rx.state
+    name_l = st.channel_names("inputs").get(left)
+    name_r = st.channel_names("inputs").get(right)
+    linked = st.stereo.get("inputs", {}).get(left)
+    print(f"left {left}: name={name_l!r} stereo={linked}; "
+          f"right {right}: name={name_r!r}")
+    if not linked:
+        print("HW-8: channel not linked — pick a linked pair")
+        return
+    # faderlin is WRITE-side only — dumps report 'fader' in dB, so
+    # expectations go through the RME curve
+    addr_l = f"/mix/in/{left}/0/faderlin"
+    addr_r = f"/mix/in/{right}/0/faderlin"
+    orig_db_l = rig.read_mix("in", left, 0, "fader")
+    orig_db_r = rig.rx.state.get_mix("in", right, 0, "fader")
+    orig_db_r = orig_db_r[0] if orig_db_r else None
+    print(f"orig fader dB: left={orig_db_l} right={orig_db_r}")
+    exp1 = gu.fader_db(0.42)
+    rig.g.send_message(addr_l, 0.42)
+    time.sleep(0.15)
+    l1 = rig.read_mix("in", left, 0, "fader")
+    print(f"wrote LEFT faderlin 0.42 -> left dB {l1} (curve predicts {exp1:.2f})")
+    rig.g.send_message(addr_r, 0.37)
+    time.sleep(0.15)
+    l2 = rig.read_mix("in", left, 0, "fader")
+    r2 = rig.rx.state.get_mix("in", right, 0, "fader")
+    r2 = r2[0] if r2 else None
+    exp2 = gu.fader_db(0.37)
+    print(f"wrote RIGHT faderlin 0.37 -> left dB {l2}, right dB {r2} "
+          f"(0.37 would be {exp2:.2f} dB)")
+    # restore via faderlin from the measured original dB
+    restore_lin = gu.fader_lin(orig_db_l if orig_db_l is not None else -300.0)
+    rig.g.send_message(addr_l, float(restore_lin))
+    time.sleep(0.15)
+    back = rig.read_mix("in", left, 0, "fader")
+    print(f"restored -> left dB {back} (orig {orig_db_l})")
+    left_ok = l1 is not None and abs(l1 - exp1) < 0.1
+    right_moved_left = l2 is not None and l1 is not None and abs(l2 - l1) > 0.1
+    right_own = r2 is not None and abs(r2 - exp2) < 0.1
+    print(f"HW-8: left-member write {'PASS' if left_ok else 'FAIL'}; "
+          f"right-member while linked: "
+          f"{'MOVED THE PAIR' if right_moved_left else 'left unchanged'}"
+          f" / right slot {'updated' if right_own else 'not updated'}")
+
+
+# ── HW-5a: FX calibration (classic 3-point) ────────────────────────
+FX_PARAMS = [
+    # (name, classic_addr, global_path)
+    ("reverb_time",     "/3/reverbTime",     "reverb/time"),
+    ("reverb_volume",   "/3/reverbVolume",   "reverb/volume"),
+    ("reverb_width",    "/3/reverbWidth",    "reverb/width"),
+    ("reverb_predelay", "/3/reverbPredelay", "reverb/predelay"),
+    ("echo_time",       "/3/echoDelaytime",  "echo/delay"),
+    ("echo_feedback",   "/3/echoFeedback",   "echo/feedback"),
+    ("echo_volume",     "/3/echoVolume",     "echo/volume"),
+    ("echo_width",      "/3/echoWidth",      "echo/width"),
+]
+
+
+def gate_calfx(rig, args):
+    # refuse if either FX is enabled (calibration sweeps would be audible)
+    rig.g.send_message("/sendall", 1.0)
+    time.sleep(4.0)
+    for en in ("reverb/enable", "echo/enable"):
+        e = rig.rx.state.get_param("fx", 0, en)
+        if e and float(e[0]) >= 0.5:
+            sys.exit(f"{en} is ON — refusing to sweep audible FX params")
+    originals = {}
+    for name, _, gpath in FX_PARAMS:
+        e = rig.rx.state.get_param("fx", 0, gpath)
+        originals[name] = e[0] if e else None
+    print("originals:", originals)
+    print(f"{'param':16} {'lo':>10} {'hi':>10}  curve   points")
+    for name, caddr, gpath in FX_PARAMS:
+        pts = rig.classic_3point(
+            caddr, lambda t0: rig.wait_param("fx", 0, gpath, t0))
+        verdict, lo, hi = curve_verdict(pts)
+        print(f"{name:16} {lo!s:>10} {hi!s:>10}  {verdict:7} {pts}")
+        # restore in now-known real units
+        if originals[name] is not None:
+            rig.g.send_message(f"/{gpath}", float(originals[name]))
+            time.sleep(0.1)
+    # verify restores with one fresh dump
+    t0 = time.time()
+    rig.g.send_message("/sendall", 1.0)
+    time.sleep(4.0)
+    bad = []
+    for name, _, gpath in FX_PARAMS:
+        e = rig.rx.state.get_param("fx", 0, gpath)
+        now = e[0] if e and e[1] > t0 else None
+        if originals[name] is not None and (
+                now is None or abs(now - originals[name]) > 1e-3):
+            bad.append((name, originals[name], now))
+    print("RESTORES VERIFIED" if not bad else f"RESTORE MISMATCH: {bad}")
+
+
+# ── HW-5b: channel-detail calibration via bank-start aiming ────────
+CH_PARAMS = [
+    ("eq_gain_1",   "/2/eqGain1",   "eq/band1gain"),
+    ("eq_freq_1",   "/2/eqFreq1",   "eq/band1freq"),
+    ("eq_q_1",      "/2/eqQ1",      "eq/band1q"),
+    ("eq_gain_3",   "/2/eqGain3",   "eq/band3gain"),
+    ("eq_freq_2",   "/2/eqFreq2",   "eq/band2freq"),
+    ("lowcut_freq", "/2/lowcutFreq", "lowcut/freq"),
+    ("lowcut_grade", "/2/lowcutGrade", "lowcut/slope"),
+    ("eq_type_1",   "/2/eqType1",   "eq/band1type"),
+    ("comp_thresh", "/2/compTrsh",  "dynamics/compthres"),
+]
+
+
+def gate_calchannel(rig, args):
+    hw = args.ch
+    rig.rechan("input", hw)
+    originals = {}
+    for name, _, gpath in CH_PARAMS:
+        e = rig.rx.state.get_param("inputs", hw, gpath)
+        originals[name] = e[0] if e else None
+    print(f"channel {hw} originals:", originals)
+
+    # aim classic page 2 at hw (page 2 mirrors the bank-start channel)
+    rig.c.send_message("/1/busInput", 1.0)
+    time.sleep(0.2)
+    rig.c.send_message("/setBankStart", float(hw))
+    time.sleep(0.3)
+    try:
+        # aim self-verification: nudge band1 gain to classic max and see it
+        # land on THIS hw channel's global feedback
+        t0 = time.time()
+        rig.c.send_message("/2/eqGain1", 1.0)
+        val, ok = rig.wait_param("inputs", hw, "eq/band1gain", t0)
+        if not ok:
+            print("AIM FAILED — /2/eqGain1 did not land on the target "
+                  "channel; aborting (nothing else written)")
+            return
+        print(f"aim verified: /2/eqGain1 1.0 -> hw {hw} band1gain = {val}")
+
+        print(f"{'param':13} {'lo':>9} {'hi':>9}  curve   points")
+        for name, caddr, gpath in CH_PARAMS:
+            pts = rig.classic_3point(
+                caddr, lambda t0, g=gpath: rig.wait_param("inputs", hw, g, t0))
+            verdict, lo, hi = curve_verdict(pts)
+            print(f"{name:13} {lo!s:>9} {hi!s:>9}  {verdict:7} {pts}")
+            if originals[name] is not None:
+                rig.g.send_message(f"/input/{hw}/{gpath}",
+                                   float(originals[name]))
+                time.sleep(0.1)
+    finally:
+        rig.c.send_message("/setBankStart", 0.0)   # classic invariant
+        time.sleep(0.1)
+
+    # verify restores
+    rig.rechan("input", hw)
+    bad = []
+    for name, _, gpath in CH_PARAMS:
+        e = rig.rx.state.get_param("inputs", hw, gpath)
+        now = e[0] if e else None
+        if originals[name] is not None and (
+                now is None or abs(now - originals[name]) > 1e-3):
+            bad.append((name, originals[name], now))
+    print("RESTORES VERIFIED" if not bad else f"RESTORE MISMATCH: {bad}")
+
+
+# ── HW-7 + wash: recall the active snapshot ────────────────────────
+def gate_wash(rig, args):
+    n = args.snap
+    # snapshot slot states only arrive in a full dump (or on change)
+    rig.g.send_message("/sendall", 1.0)
+    rig.rx.wait_for(lambda s: len(s.snapshots) >= 8, 8.0)
+    pre = dict(rig.rx.state.snapshots)
+    print(f"snapshot state pre-wash: {pre}")
+    if pre.get(n) not in (2.0, 3.0):
+        # 2=active unmodified, 3=active+changed (our session's writes)
+        sys.exit(f"slot {n} is not the active snapshot ({pre}) — "
+                 f"refusing to recall")
+    with rig.rx.state._lock:
+        rig.rx.state.snapshots.pop(n, None)   # force fresh confirmation
+    rig.g.send_message(f"/snapshot/load/{n}", 1.0)
+    ok = rig.rx.wait_for(lambda s: s.snapshots.get(n) == 2.0, 4.0)
+    print(f"recalled /snapshot/load/{n} -> confirmed 2.0: {ok} "
+          f"(state now {dict(rig.rx.state.snapshots)})")
+    print("HW-7: 1-based recall + feedback confirm — "
+          + ("PASS (device state washed to stored snapshot)" if ok else
+             "NO CONFIRM — investigate before trusting load_snapshot"))
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    sub = ap.add_subparsers(dest="cmd", required=True)
+    s = sub.add_parser("enables"); s.add_argument("--ch", type=int, default=26)
+    s = sub.add_parser("pan")
+    s.add_argument("--in-ch", type=int, default=26)
+    s.add_argument("--out-ch", type=int, default=0)
+    s = sub.add_parser("stereo"); s.add_argument("--left", type=int, default=28)
+    sub.add_parser("calfx")
+    s = sub.add_parser("calchannel"); s.add_argument("--ch", type=int, default=26)
+    s = sub.add_parser("wash"); s.add_argument("--snap", type=int, default=4)
+    args = ap.parse_args()
+    rig = Rig()
+    try:
+        {"enables": gate_enables, "pan": gate_pan, "stereo": gate_stereo,
+         "calfx": gate_calfx, "calchannel": gate_calchannel,
+         "wash": gate_wash}[args.cmd](rig, args)
+    finally:
+        rig.stop()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/global_osc_probe.py
+++ b/tools/global_osc_probe.py
@@ -1,0 +1,213 @@
+"""Global OSC hardware harness (#25) — runs on the TotalMix host.
+
+Safe by construction: sends only /sendchan, /sendall, /sendstate (read
+triggers), /mix/... faderlin and /input/N/mute writes inside write-verify
+(which restores what it changed). The classic fatal op (/setSubmix) does
+not exist in this namespace and no classic-port code path is present.
+
+Subcommands:
+  listen        print decoded feedback for N seconds (HW-1: bundle dispatch)
+  sendchan      dump one channel's full state in real units
+  names         compare live names vs the physical table (startup mandate)
+  write-verify  read faderlin -> write new -> read back -> RESTORE
+  fader-curve   HW-2: classic volume writes vs global faderlin readback
+  heartbeat     watchdog demo (age, then /sendstate refresh)
+"""
+import argparse
+import json
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from pythonosc.udp_client import SimpleUDPClient
+
+import global_units as gu
+import physical_table as pt
+from global_listener import GlobalOSCListener
+
+DEFAULT_HOST = os.getenv("GLOBAL_OSC_IP", "192.168.1.61")
+DEFAULT_PORT = int(os.getenv("GLOBAL_OSC_PORT", "7002"))
+DEFAULT_LISTEN = int(os.getenv("GLOBAL_OSC_LISTEN_PORT", "9002"))
+CLASSIC_PORT = int(os.getenv("OSC_PORT", "7001"))
+
+
+def make(args):
+    tx = SimpleUDPClient(args.host, args.port)
+    rx = GlobalOSCListener(args.listen_port)
+    if not rx.start():
+        sys.exit("listener bind failed (is something else on the port?)")
+    return tx, rx
+
+
+def load_table():
+    # the MEASURED table lives on the production bridge — prefer it
+    bridge_url = os.getenv("BRIDGE_URL", "http://192.168.1.41:8088")
+    try:
+        import urllib.request
+        with urllib.request.urlopen(f"{bridge_url}/api/device/physical_table",
+                                    timeout=4) as r:
+            return json.load(r)
+    except Exception:
+        pass
+    for p in ("ufx2_channel_map.json", "ufx2_channel_map.example.json"):
+        path = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), p)
+        if os.path.exists(path):
+            with open(path, encoding="utf-8") as f:
+                return json.load(f).get("physical_table")
+    return None
+
+
+def cmd_listen(args):
+    tx, rx = make(args)
+    t0 = time.time()
+    last = 0
+    while time.time() - t0 < args.secs:
+        time.sleep(0.5)
+        st = rx.state
+        if st.message_count != last:
+            last = st.message_count
+    print(f"messages: {rx.state.message_count}")
+    print(f"status: {rx.state.status}")
+    print(f"heartbeat age: {rx.state.heartbeat_age()}")
+    with rx.state._lock:
+        addrs = sorted({(k[0], k[2]) for k in rx.state.params})
+    for a in addrs[:40]:
+        print(" ", a)
+    rx.stop()
+
+
+def cmd_sendchan(args):
+    tx, rx = make(args)
+    tx.send_message(f"/sendchan/{args.row}/{args.ch}", 1.0)
+    time.sleep(1.5)
+    row_key = {"input": "inputs", "playback": "playbacks",
+               "output": "outputs"}[args.row]
+    with rx.state._lock:
+        entries = {k[2]: v["value"] for k, v in rx.state.params.items()
+                   if k[0] == row_key and k[1] == args.ch}
+    names = rx.state.channel_names(row_key)
+    print(f"{args.row} hw {args.ch}  name={names.get(args.ch)!r}  "
+          f"stereo={rx.state.stereo.get(row_key, {}).get(args.ch)}")
+    for k in sorted(entries):
+        print(f"  {k} = {entries[k]}")
+    rx.stop()
+
+
+def cmd_names(args):
+    tx, rx = make(args)
+    tx.send_message("/sendall", 1.0)
+    time.sleep(4.0)
+    table = load_table()
+    ok = True
+    for row_key in ("inputs", "outputs"):
+        live = rx.state.channel_names(row_key)
+        print(f"— {row_key}: {len(live)} live names")
+        for hw in sorted(live):
+            name = live[hw]
+            expected = pt.resolve_start(table, row_key, name) if table else None
+            mark = ""
+            if table is not None and expected is not None and expected != hw:
+                # the pair-left rule: global names arrive at the LEFT member
+                # only, so a name resolving to a lower member is fine when
+                # stereo; a genuine mismatch is loud
+                if not rx.state.stereo.get(row_key, {}).get(expected):
+                    mark = f"  ⚠ table says {expected}"
+                    ok = False
+            print(f"  {hw:2d}  {name}{mark}")
+    print("TABLE MATCH" if ok else "MISMATCHES FOUND — investigate before trusting")
+    rx.stop()
+
+
+def cmd_write_verify(args):
+    tx, rx = make(args)
+    table = load_table()
+    if table is None:
+        sys.exit("no physical table — refusing to write")
+    if (str(args.in_ch) not in table["rows"].get("inputs", {})
+            or str(args.out_ch) not in table["rows"].get("outputs", {})):
+        sys.exit("channel(s) not in the measured table — refusing to write")
+    addr = f"/mix/in/{args.in_ch}/{args.out_ch}/faderlin"
+    tx.send_message(f"/sendchan/input/{args.in_ch}", 1.0)
+    time.sleep(1.0)
+    before = rx.state.get_mix("in", args.in_ch, args.out_ch, "faderlin")
+    print(f"before: {before}")
+    t0 = time.time()
+    tx.send_message(addr, float(args.value))
+    got = rx.wait_for(
+        lambda s: (s.get_mix("in", args.in_ch, args.out_ch, "faderlin") or
+                   (None, 0))[1] > t0, 2.0)
+    after = rx.state.get_mix("in", args.in_ch, args.out_ch, "faderlin")
+    print(f"write {args.value} -> echoed={got}, readback: {after}")
+    restore = before[0] if before else 0.0
+    tx.send_message(addr, float(restore))
+    time.sleep(0.3)
+    print(f"restored to {restore}")
+    rx.stop()
+
+
+def cmd_fader_curve(args):
+    """HW-2: write classic /1/volume{strip} values on the CLASSIC port and
+    read the global faderlin feedback — verifies the identity hypothesis.
+    Requires the target strip visible at bank 0 on the input row, and the
+    submix currently selected on the classic remote to be out_ch's."""
+    tx, rx = make(args)
+    classic = SimpleUDPClient(args.host, CLASSIC_PORT)
+    pairs = []
+    for v in (0.0, 0.25, 0.5, 0.75, 1.0):
+        t0 = time.time()
+        classic.send_message(f"/1/volume{args.strip}", float(v))
+        rx.wait_for(
+            lambda s: (s.get_mix("in", args.in_ch, args.out_ch, "faderlin")
+                       or (None, 0))[1] > t0, 2.0)
+        lin = rx.state.get_mix("in", args.in_ch, args.out_ch, "faderlin")
+        db = rx.state.get_mix("in", args.in_ch, args.out_ch, "fader")
+        pairs.append((v, lin[0] if lin else None, db[0] if db else None))
+        print(f"classic {v:5.2f} -> faderlin {pairs[-1][1]} "
+              f"(dB {pairs[-1][2]}; curve predicts {gu.fader_db(v):.2f})")
+        time.sleep(0.2)
+    ident = all(l is not None and abs(l - v) < 0.02 for v, l, _ in pairs)
+    print("IDENTITY CONFIRMED" if ident else "NOT IDENTITY — use dB conversion")
+    rx.stop()
+
+
+def cmd_heartbeat(args):
+    tx, rx = make(args)
+    time.sleep(2.5)
+    print(f"age after 2.5s listen: {rx.state.heartbeat_age()}")
+    tx.send_message("/sendstate", 1.0)
+    time.sleep(1.0)
+    print(f"status: {rx.state.status}, age: {rx.state.heartbeat_age()}")
+    rx.stop()
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--host", default=DEFAULT_HOST)
+    ap.add_argument("--port", type=int, default=DEFAULT_PORT)
+    ap.add_argument("--listen-port", type=int, default=DEFAULT_LISTEN)
+    sub = ap.add_subparsers(dest="cmd", required=True)
+    s = sub.add_parser("listen"); s.add_argument("--secs", type=float, default=5)
+    s = sub.add_parser("sendchan")
+    s.add_argument("--row", default="input",
+                   choices=["input", "playback", "output"])
+    s.add_argument("--ch", type=int, required=True)
+    sub.add_parser("names")
+    s = sub.add_parser("write-verify")
+    s.add_argument("--in-ch", type=int, required=True)
+    s.add_argument("--out-ch", type=int, required=True)
+    s.add_argument("--value", type=float, required=True)
+    s = sub.add_parser("fader-curve")
+    s.add_argument("--strip", type=int, required=True)
+    s.add_argument("--in-ch", type=int, required=True)
+    s.add_argument("--out-ch", type=int, required=True)
+    sub.add_parser("heartbeat")
+    args = ap.parse_args()
+    {"listen": cmd_listen, "sendchan": cmd_sendchan, "names": cmd_names,
+     "write-verify": cmd_write_verify, "fader-curve": cmd_fader_curve,
+     "heartbeat": cmd_heartbeat}[args.cmd](args)
+
+
+if __name__ == "__main__":
+    main()

--- a/web/web_client.py
+++ b/web/web_client.py
@@ -444,6 +444,34 @@ async def get_physical_table():
     return table
 
 
+@app.get("/api/device/global")
+def get_global_osc_status():
+    # sync endpoint on purpose: alive() may block ~2s on a /sendstate
+    # probe — FastAPI runs sync handlers in the threadpool
+    """Global OSC (#25) transport/listener status: which transport writes,
+    heartbeat liveness, and what the Global listener has learned."""
+    import config as cfg
+    out = {
+        "transport": cfg.OSC_TRANSPORT,
+        "listener_enabled": cfg.ENABLE_GLOBAL_OSC_LISTENER,
+        "running": bridge.global_listener is not None,
+    }
+    if bridge.global_listener:
+        st = bridge.global_listener.state
+        out.update({
+            "listen_port": bridge.global_listener.port,
+            "heartbeat_age_s": st.heartbeat_age(),
+            "status": dict(st.status),
+            "message_count": st.message_count,
+            "names": {row: st.channel_names(row)
+                      for row in ("inputs", "playbacks", "outputs")},
+            "snapshots": {str(k): v for k, v in st.snapshots.items()},
+        })
+    if bridge.global_transport:
+        out["alive"] = bridge.global_transport.alive()
+    return out
+
+
 @app.post("/api/device/probe")
 async def probe_device():
     """Liveness probe (kept through #24 — TASK 6 deviation fix): a state-
@@ -665,5 +693,6 @@ async def startup_event():
     threading.Thread(target=_keepalive, daemon=True).start()
     bridge.start_mqtt()
     bridge.start_osc_listener()
+    bridge.start_global_osc()   # #25: no-op unless enabled via env
     bridge.main_loop = asyncio.get_running_loop()
     print(f"🚀 TotalMix Web Client + Bridge started (port {WEB_PORT}) — MQTT ACTIVE")


### PR DESCRIPTION
Migrates macro writes to the TotalMix FX 2.1 Global OSC namespace behind an env flag. Classic remains the default and the whole classic path is untouched — `OSC_TRANSPORT=global` flips writes to absolute addressing (no aiming, no bank/row state, no restores); `ENABLE_GLOBAL_OSC_LISTENER=true` runs the new listener in shadow mode alongside classic.

- `global_units.py`: RME fader curve (verbatim port, hardware-verified to 3 decimals) + declarative param map; uncalibrated transforms refuse.
- `global_listener.py`: bundle-framed feedback listener with (row, hw, param) real-unit state, heartbeat, name/stereo tracking.
- `global_transport.py`: name→hardware-channel resolution (live names first, physical table fallback, mono-name-while-linked pair default), mix/channel/fx writers, 1-based feedback-confirmed snapshot recall, name-sync into the physical table.
- Bridge/MQTT/web seams + `GET /api/device/global` status endpoint.
- Suite 190 green; live shadow-mode smoke against the UFX II passed (heartbeat, 47 names, 89 aliases auto-learned).

Remaining before merge: hardware gates HW-3/5/6/8 (enable semantics, unit calibrations, pan, stereo pairs), PRECIOUS shadow deployment + side-by-side matrix.

https://claude.ai/code/session_0158PkmMAqkDFKJh1U6U1VPP